### PR TITLE
feat(frontend): add plan edit UI (US-012)

### DIFF
--- a/src/pages/PlansPage.jsx
+++ b/src/pages/PlansPage.jsx
@@ -8,6 +8,7 @@ const PlansPage = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [showModal, setShowModal] = useState(false)
+  const [editingPlan, setEditingPlan] = useState(null)
   const [formData, setFormData] = useState({ name: '', description: '' })
   const [submitting, setSubmitting] = useState(false)
   const [formError, setFormError] = useState('')
@@ -28,14 +29,19 @@ const PlansPage = () => {
     }
   }
 
-  const handleOpenModal = () => {
-    setFormData({ name: '', description: '' })
+  const handleOpenModal = (plan = null) => {
+    setEditingPlan(plan)
+    setFormData({
+      name: plan ? plan.name : '',
+      description: plan ? (plan.description || '') : '',
+    })
     setFormError('')
     setShowModal(true)
   }
 
   const handleCloseModal = () => {
     setShowModal(false)
+    setEditingPlan(null)
     setFormError('')
   }
 
@@ -50,7 +56,11 @@ const PlansPage = () => {
     setSubmitting(true)
 
     try {
-      await api.createPlan(formData)
+      if (editingPlan) {
+        await api.updatePlan(editingPlan.id, formData)
+      } else {
+        await api.createPlan(formData)
+      }
       await fetchPlans()
       handleCloseModal()
     } catch (err) {
@@ -131,12 +141,20 @@ const PlansPage = () => {
                 <span className={styles.planMeta}>
                   {plan.budget_item_count} Posten - Erstellt am {formatDate(plan.created_at)}
                 </span>
-                <button
-                  className="btn"
-                  onClick={() => navigate(`/plans/${plan.id}`)}
-                >
-                  Details
-                </button>
+                <div className={styles.planActions}>
+                  <button
+                    className={styles.editBtn}
+                    onClick={() => handleOpenModal(plan)}
+                  >
+                    Bearbeiten
+                  </button>
+                  <button
+                    className="btn"
+                    onClick={() => navigate(`/plans/${plan.id}`)}
+                  >
+                    Details
+                  </button>
+                </div>
               </div>
             </div>
           ))}
@@ -150,7 +168,7 @@ const PlansPage = () => {
             onClick={(e) => e.stopPropagation()}
           >
             <div className={styles.modalHeader}>
-              <h2>Neuen Plan erstellen</h2>
+              <h2>{editingPlan ? 'Plan bearbeiten' : 'Neuen Plan erstellen'}</h2>
               <button className={styles.closeBtn} onClick={handleCloseModal}>
                 &times;
               </button>
@@ -201,7 +219,9 @@ const PlansPage = () => {
                   Abbrechen
                 </button>
                 <button type="submit" className="btn" disabled={submitting}>
-                  {submitting ? 'Wird erstellt...' : 'Erstellen'}
+                  {submitting
+                    ? editingPlan ? 'Wird gespeichert...' : 'Wird erstellt...'
+                    : editingPlan ? 'Speichern' : 'Erstellen'}
                 </button>
               </div>
             </form>

--- a/src/pages/PlansPage.module.css
+++ b/src/pages/PlansPage.module.css
@@ -105,6 +105,28 @@
   margin-top: 1rem;
 }
 
+.planActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.editBtn {
+  background: none;
+  border: 2px solid rgba(128, 128, 128, 0.4);
+  border-radius: 14px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-family: "Roboto Mono", monospace;
+  font-size: 14px;
+  color: var(--text-color);
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.editBtn:hover {
+  border-color: var(--text-color);
+  background-color: rgba(128, 128, 128, 0.1);
+}
+
 .planMeta {
   font-size: 13px;
   opacity: 0.6;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -63,3 +63,11 @@ export async function createPlan(data) {
     body: JSON.stringify(data),
   })
 }
+
+export async function updatePlan(planId, data) {
+  return request(`/plans/${planId}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+}


### PR DESCRIPTION
- Extend PlansPage modal to support editing existing plans via PUT /api/v1/plans/{id}. Add edit button to each plan card.