### PR TITLE
feat(frontend): add plan delete UI (US-013)

### DIFF
--- a/src/pages/PlansPage.jsx
+++ b/src/pages/PlansPage.jsx
@@ -50,6 +50,18 @@ const PlansPage = () => {
     setFormData((prev) => ({ ...prev, [name]: value }))
   }
 
+  const handleDelete = async (plan) => {
+    if (!window.confirm(`Plan "${plan.name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.`)) {
+      return
+    }
+    try {
+      await api.deletePlan(plan.id)
+      await fetchPlans()
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
   const handleSubmit = async (e) => {
     e.preventDefault()
     setFormError('')
@@ -147,6 +159,12 @@ const PlansPage = () => {
                     onClick={() => handleOpenModal(plan)}
                   >
                     Bearbeiten
+                  </button>
+                  <button
+                    className={styles.deleteBtn}
+                    onClick={() => handleDelete(plan)}
+                  >
+                    Löschen
                   </button>
                   <button
                     className="btn"

--- a/src/pages/PlansPage.module.css
+++ b/src/pages/PlansPage.module.css
@@ -127,6 +127,33 @@
   background-color: rgba(128, 128, 128, 0.1);
 }
 
+.deleteBtn {
+  background: none;
+  border: 2px solid rgba(198, 40, 40, 0.4);
+  border-radius: 14px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  font-family: "Roboto Mono", monospace;
+  font-size: 14px;
+  color: #c62828;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.deleteBtn:hover {
+  border-color: #c62828;
+  background-color: rgba(198, 40, 40, 0.08);
+}
+
+:global([data-theme="dark"]) .deleteBtn {
+  color: #ef9a9a;
+  border-color: rgba(239, 154, 154, 0.4);
+}
+
+:global([data-theme="dark"]) .deleteBtn:hover {
+  border-color: #ef9a9a;
+  background-color: rgba(239, 154, 154, 0.08);
+}
+
 .planMeta {
   font-size: 13px;
   opacity: 0.6;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -71,3 +71,17 @@ export async function updatePlan(planId, data) {
     body: JSON.stringify(data),
   })
 }
+
+export async function deletePlan(planId) {
+  const token = localStorage.getItem('token')
+  const headers = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  const response = await fetch(`/api/v1/plans/${planId}`, {
+    method: 'DELETE',
+    headers,
+  })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.detail || `HTTP ${response.status}`)
+  }
+}


### PR DESCRIPTION
- Add delete button to plan cards with confirmation dialog.

- Calls DELETE /api/v1/plans/{id} and refreshes plan list on success.