### PR TITLE
Fix multiple frontend bugs found during initial testing

### DIFF
--- a/src/pages/PlanDetailPage.jsx
+++ b/src/pages/PlanDetailPage.jsx
@@ -218,7 +218,7 @@ const PlanDetailPage = () => {
             <p className={styles.description}>{plan.description}</p>
           )}
         </div>
-        <button className="btn" onClick={handleOpenModal}>
+        <button className="btn" onClick={() => handleOpenModal()}>
           Posten hinzufügen
         </button>
       </div>
@@ -251,7 +251,7 @@ const PlanDetailPage = () => {
       {items.length === 0 ? (
         <div className={styles.empty}>
           <p>Noch keine Budget-Posten vorhanden.</p>
-          <button className="btn" onClick={handleOpenModal}>
+          <button className="btn" onClick={() => handleOpenModal()}>
             Ersten Posten hinzufügen
           </button>
         </div>

--- a/src/pages/PlansPage.jsx
+++ b/src/pages/PlansPage.jsx
@@ -8,9 +8,6 @@ const PlansPage = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [showModal, setShowModal] = useState(false)
-  const [formData, setFormData] = useState({ name: '', description: '' })
-  const [submitting, setSubmitting] = useState(false)
-  const [formError, setFormError] = useState('')
   const [editingPlan, setEditingPlan] = useState(null)
   const [formData, setFormData] = useState({ name: '', description: '' })
   const [submitting, setSubmitting] = useState(false)
@@ -32,8 +29,6 @@ const PlansPage = () => {
     }
   }
 
-  const handleOpenModal = () => {
-    setFormData({ name: '', description: '' })
   const handleOpenModal = (plan = null) => {
     setEditingPlan(plan)
     setFormData({
@@ -73,9 +68,6 @@ const PlansPage = () => {
     setSubmitting(true)
 
     try {
-      await api.createPlan(formData)
-      await fetchPlans()
-      handleCloseModal()
       if (editingPlan) {
         await api.updatePlan(editingPlan.id, formData)
         await fetchPlans()
@@ -115,7 +107,7 @@ const PlansPage = () => {
       <div className={styles.header}>
         <h1>Meine Pläne</h1>
         {plans.length > 0 && (
-          <button className="btn" onClick={handleOpenModal}>
+          <button className="btn" onClick={() => handleOpenModal()}>
             Neuen Plan erstellen
           </button>
         )}
@@ -126,7 +118,7 @@ const PlansPage = () => {
       {plans.length === 0 ? (
         <div className={styles.empty}>
           <p>Du hast noch keine Budget-Pläne erstellt.</p>
-          <button className="btn" onClick={handleOpenModal}>
+          <button className="btn" onClick={() => handleOpenModal()}>
             Ersten Plan erstellen
           </button>
         </div>
@@ -138,8 +130,6 @@ const PlansPage = () => {
               {plan.description && (
                 <p className={styles.planDescription}>{plan.description}</p>
               )}
-              <div className={styles.planMeta}>
-                Erstellt am {formatDate(plan.created_at)}
               <div className={styles.planStats}>
                 <div className={styles.statRow}>
                   <span className={styles.statLabel}>Einnahmen</span>
@@ -197,7 +187,6 @@ const PlansPage = () => {
             onClick={(e) => e.stopPropagation()}
           >
             <div className={styles.modalHeader}>
-              <h2>Neuen Plan erstellen</h2>
               <h2>{editingPlan ? 'Plan bearbeiten' : 'Neuen Plan erstellen'}</h2>
               <button className={styles.closeBtn} onClick={handleCloseModal}>
                 &times;
@@ -249,7 +238,6 @@ const PlansPage = () => {
                   Abbrechen
                 </button>
                 <button type="submit" className="btn" disabled={submitting}>
-                  {submitting ? 'Wird erstellt...' : 'Erstellen'}
                   {submitting
                     ? editingPlan ? 'Wird gespeichert...' : 'Wird erstellt...'
                     : editingPlan ? 'Speichern' : 'Erstellen'}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -13,7 +13,11 @@ async function request(path, options = {}) {
   const response = await fetch(`${BASE_URL}${path}`, { ...options, headers })
   if (!response.ok) {
     const data = await response.json().catch(() => ({}))
-    throw new Error(data.detail || `HTTP ${response.status}`)
+    const detail = data.detail
+    const message = Array.isArray(detail)
+      ? detail.map((e) => `${e.loc?.at(-1) ?? '?'}: ${e.msg}`).join(', ')
+      : detail || `HTTP ${response.status}`
+    throw new Error(message)
   }
   return response.json()
 }
@@ -53,16 +57,16 @@ export async function logout() {
 
 // Categories
 export async function getCategories() {
-  return request('/categories')
+  return request('/categories/')
 }
 
 // Budget Items
 export async function getBudgetItems(planId) {
-  return request(`/plans/${planId}/items`)
+  return request(`/plans/${planId}/items/`)
 }
 
 export async function createBudgetItem(planId, data) {
-  return request(`/plans/${planId}/items`, {
+  return request(`/plans/${planId}/items/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
@@ -93,11 +97,11 @@ export async function deleteBudgetItem(planId, itemId) {
 
 // Plans
 export async function getPlans() {
-  return request('/plans')
+  return request('/plans/')
 }
 
 export async function createPlan(data) {
-  return request('/plans', {
+  return request('/plans/', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),


### PR DESCRIPTION
- api.js: add trailing slashes to collection endpoints to prevent 307 redirects that bypass Vite proxy and drop Authorization header

- api.js: handle Pydantic v2 array error format in request()

- PlansPage.jsx: remove merge artifacts (duplicate state, broken JSX, mixed handleSubmit logic)

- PlanDetailPage.jsx + PlansPage.jsx: wrap onClick handlers in arrow functions to prevent SyntheticEvent being passed as item parameter