### PR TITLE
feat(frontend): implement dashboard with active plan and plan comparison

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -1,8 +1,245 @@
+import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import * as api from '../utils/api'
+import styles from './DashboardPage.module.css'
+
+const formatCurrency = (value) =>
+  new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(value)
+
 const DashboardPage = () => {
+  const [plans, setPlans] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [activePlanId, setActivePlanId] = useState(null)
+  const [comparePlanIds, setComparePlanIds] = useState([])
+
+  useEffect(() => {
+    const storedActive = parseInt(localStorage.getItem('activePlanId'))
+    if (!isNaN(storedActive)) setActivePlanId(storedActive)
+
+    try {
+      const storedCompare = JSON.parse(localStorage.getItem('comparePlanIds') || '[]')
+      if (Array.isArray(storedCompare)) {
+        setComparePlanIds(storedCompare.slice(0, 3))
+      }
+    } catch {
+      // localStorage corrupted - ignore
+    }
+
+    api.getPlans()
+      .then((data) => setPlans(data))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleSetActivePlan = (e) => {
+    const value = e.target.value
+    if (value === '') {
+      setActivePlanId(null)
+      localStorage.removeItem('activePlanId')
+    } else {
+      const id = parseInt(value)
+      setActivePlanId(id)
+      localStorage.setItem('activePlanId', String(id))
+    }
+  }
+
+  const handleToggleComparePlan = (planId) => {
+    setComparePlanIds((prev) => {
+      let next
+      if (prev.includes(planId)) {
+        next = prev.filter((id) => id !== planId)
+      } else if (prev.length < 3) {
+        next = [...prev, planId]
+      } else {
+        return prev
+      }
+      localStorage.setItem('comparePlanIds', JSON.stringify(next))
+      return next
+    })
+  }
+
+  const activePlan = plans.find((p) => p.id === activePlanId) ?? null
+  const comparePlans = plans.filter((p) => comparePlanIds.includes(p.id))
+
+  if (loading) return <div className={styles.loading}>Wird geladen...</div>
+  if (error) return <div className={styles.error}>{error}</div>
+
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Dashboard</h1>
-      <p>Wird in späteren User Stories implementiert.</p>
+    <div className={styles.container}>
+      <div className={styles.pageHeader}>
+        <h1>Dashboard</h1>
+      </div>
+
+      {/* Aktiver Plan */}
+      <section className={styles.activePlanSection}>
+        <div className={styles.sectionHeader}>
+          <h2>Aktiver Plan</h2>
+          {plans.length > 0 && (
+            <select
+              className={styles.planSelector}
+              value={activePlanId ?? ''}
+              onChange={handleSetActivePlan}
+            >
+              <option value="">Plan auswahlen...</option>
+              {plans.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {plans.length === 0 ? (
+          <div className={styles.emptyHint}>
+            Noch keine Plane vorhanden. <Link to="/plans">Plan erstellen</Link>
+          </div>
+        ) : activePlanId === null ? (
+          <div className={styles.emptyHint}>
+            Wahle einen Plan aus dem Dropdown aus, um dessen Kennzahlen hier anzuzeigen.
+          </div>
+        ) : activePlan === null ? (
+          <div className={styles.emptyHint}>
+            Der zuletzt aktive Plan wurde geloscht. Bitte einen neuen Plan auswahlen.
+          </div>
+        ) : (
+          <div className={styles.activePlanCard}>
+            <div className={styles.activePlanHeader}>
+              <span className={styles.activePlanName}>{activePlan.name}</span>
+              <Link to={`/plans/${activePlan.id}`} className="btn">
+                Plan offnen
+              </Link>
+            </div>
+            {activePlan.description && (
+              <p className={styles.activePlanDescription}>{activePlan.description}</p>
+            )}
+            <div className={styles.statsGrid}>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Einnahmen</span>
+                <span className={`${styles.statValue} ${styles.statIncome}`}>
+                  {formatCurrency(activePlan.total_monthly_income)}
+                </span>
+                <span className={styles.statSub}>/ Monat</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Ausgaben</span>
+                <span className={`${styles.statValue} ${styles.statExpenses}`}>
+                  {formatCurrency(activePlan.total_monthly_expenses)}
+                </span>
+                <span className={styles.statSub}>/ Monat</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Bilanz</span>
+                <span
+                  className={`${styles.statValue} ${
+                    activePlan.monthly_balance >= 0 ? styles.statPositive : styles.statNegative
+                  }`}
+                >
+                  {formatCurrency(activePlan.monthly_balance)}
+                </span>
+                <span className={styles.statSub}>/ Monat</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Posten</span>
+                <span className={styles.statValue}>{activePlan.budget_item_count}</span>
+                <span className={styles.statSub}>Budget-Posten</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Plan-Vergleich */}
+      {plans.length > 1 && (
+        <section className={styles.compareSection}>
+          <div className={styles.sectionHeader}>
+            <h2>Plan-Vergleich</h2>
+            {comparePlanIds.length >= 3 && (
+              <span className={styles.compareMaxHint}>Maximum erreicht (3 Plane)</span>
+            )}
+          </div>
+
+          <div className={styles.comparePicker}>
+            {plans.map((p) => {
+              const checked = comparePlanIds.includes(p.id)
+              const disabled = !checked && comparePlanIds.length >= 3
+              return (
+                <label
+                  key={p.id}
+                  className={`${styles.compareOption} ${disabled ? styles.compareOptionDisabled : ''}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={disabled}
+                    onChange={() => handleToggleComparePlan(p.id)}
+                  />
+                  {p.name}
+                </label>
+              )
+            })}
+          </div>
+
+          {comparePlans.length === 0 ? (
+            <div className={styles.emptyHint}>
+              Wahle bis zu 3 Plane aus, um sie nebeneinander zu vergleichen.
+            </div>
+          ) : (
+            <div className={styles.compareTableWrapper}>
+              <table className={styles.compareTable}>
+                <thead>
+                  <tr>
+                    <th className={styles.compareRowLabel}></th>
+                    {comparePlans.map((p) => (
+                      <th key={p.id} className={styles.compareTh}>{p.name}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td className={styles.compareRowLabel}>Einnahmen</td>
+                    {comparePlans.map((p) => (
+                      <td key={p.id} className={`${styles.compareTd} ${styles.compareValueIncome}`}>
+                        {formatCurrency(p.total_monthly_income)}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <td className={styles.compareRowLabel}>Ausgaben</td>
+                    {comparePlans.map((p) => (
+                      <td key={p.id} className={`${styles.compareTd} ${styles.compareValueExpenses}`}>
+                        {formatCurrency(p.total_monthly_expenses)}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr className={styles.compareBalanceRow}>
+                    <td className={styles.compareRowLabel}>Bilanz</td>
+                    {comparePlans.map((p) => (
+                      <td
+                        key={p.id}
+                        className={`${styles.compareTd} ${
+                          p.monthly_balance >= 0
+                            ? styles.compareValuePositive
+                            : styles.compareValueNegative
+                        }`}
+                      >
+                        {formatCurrency(p.monthly_balance)}
+                      </td>
+                    ))}
+                  </tr>
+                  <tr>
+                    <td className={styles.compareRowLabel}>Posten</td>
+                    {comparePlans.map((p) => (
+                      <td key={p.id} className={styles.compareTd}>
+                        {p.budget_item_count}
+                      </td>
+                    ))}
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      )}
     </div>
   )
 }

--- a/src/pages/DashboardPage.module.css
+++ b/src/pages/DashboardPage.module.css
@@ -1,0 +1,311 @@
+.container {
+  padding: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.pageHeader h1 {
+  margin: 0;
+}
+
+/* Sections */
+.activePlanSection,
+.compareSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.sectionHeader h2 {
+  margin: 0;
+  font-family: "Rubik", sans-serif;
+  font-size: 18px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+/* Plan selector */
+.planSelector {
+  padding: 0.45rem 0.75rem;
+  border-radius: 8px;
+  border: 2px solid rgba(128, 128, 128, 0.3);
+  background-color: var(--input-bg);
+  color: var(--text-color);
+  font-family: "Roboto Mono", monospace;
+  font-size: 13px;
+  cursor: pointer;
+  outline: none;
+}
+
+.planSelector:focus {
+  border-color: var(--text-color);
+}
+
+/* Active plan card */
+.activePlanCard {
+  background-color: var(--section-bg);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.activePlanHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.activePlanName {
+  font-family: "Rubik", sans-serif;
+  font-size: 20px;
+  font-weight: 800;
+}
+
+.activePlanDescription {
+  margin: 0;
+  opacity: 0.65;
+  font-size: 14px;
+}
+
+/* Stats grid */
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-top: 0.25rem;
+}
+
+.statBox {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 1rem;
+  background-color: var(--section-header-bg);
+  border-radius: 8px;
+}
+
+.statLabel {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.55;
+}
+
+.statValue {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.statSub {
+  font-size: 11px;
+  opacity: 0.45;
+}
+
+.statIncome {
+  color: #2e7d32;
+}
+
+.statExpenses {
+  color: #c62828;
+}
+
+.statPositive {
+  color: #2e7d32;
+}
+
+.statNegative {
+  color: #c62828;
+}
+
+:global([data-theme="dark"]) .statIncome,
+:global([data-theme="dark"]) .statPositive {
+  color: #66bb6a;
+}
+
+:global([data-theme="dark"]) .statExpenses,
+:global([data-theme="dark"]) .statNegative {
+  color: #ef9a9a;
+}
+
+/* Compare picker */
+.comparePicker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.compareOption {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.9rem;
+  border: 1px solid rgba(128, 128, 128, 0.35);
+  border-radius: 20px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+  user-select: none;
+}
+
+.compareOption:hover {
+  background-color: rgba(128, 128, 128, 0.08);
+}
+
+.compareOption input[type="checkbox"] {
+  accent-color: var(--text-color);
+  cursor: pointer;
+}
+
+.compareOptionDisabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.compareOptionDisabled:hover {
+  background-color: transparent;
+}
+
+.compareMaxHint {
+  font-size: 12px;
+  opacity: 0.55;
+}
+
+/* Compare table */
+.compareTableWrapper {
+  overflow-x: auto;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.compareTable {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: var(--section-bg);
+  font-size: 14px;
+}
+
+.compareTh {
+  padding: 0.9rem 1.25rem;
+  text-align: left;
+  font-family: "Rubik", sans-serif;
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 2px solid rgba(128, 128, 128, 0.15);
+  white-space: nowrap;
+}
+
+.compareRowLabel {
+  padding: 0.8rem 1.25rem;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.55;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.compareTd {
+  padding: 0.8rem 1.25rem;
+  font-weight: 700;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.1);
+  vertical-align: middle;
+}
+
+.compareTable tbody tr:last-child .compareTd,
+.compareTable tbody tr:last-child .compareRowLabel {
+  border-bottom: none;
+}
+
+.compareBalanceRow .compareTd,
+.compareBalanceRow .compareRowLabel {
+  border-top: 2px solid rgba(128, 128, 128, 0.15);
+  border-bottom: 2px solid rgba(128, 128, 128, 0.15);
+}
+
+.compareValueIncome {
+  color: #2e7d32;
+}
+
+.compareValueExpenses {
+  color: #c62828;
+}
+
+.compareValuePositive {
+  color: #2e7d32;
+}
+
+.compareValueNegative {
+  color: #c62828;
+}
+
+:global([data-theme="dark"]) .compareValueIncome,
+:global([data-theme="dark"]) .compareValuePositive {
+  color: #66bb6a;
+}
+
+:global([data-theme="dark"]) .compareValueExpenses,
+:global([data-theme="dark"]) .compareValueNegative {
+  color: #ef9a9a;
+}
+
+/* Utility */
+.emptyHint {
+  padding: 1.5rem;
+  opacity: 0.65;
+  font-size: 14px;
+  background-color: var(--section-bg);
+  border-radius: 10px;
+}
+
+.emptyHint a {
+  color: var(--text-color);
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.loading {
+  text-align: center;
+  padding: 3rem;
+  opacity: 0.7;
+}
+
+.error {
+  text-align: center;
+  padding: 3rem;
+  color: #c62828;
+}
+
+:global([data-theme="dark"]) .error {
+  color: #ef9a9a;
+}
+
+/* Responsive */
+@media (width >= 800px) {
+  .container {
+    padding: 3rem;
+  }
+}
+
+@media (width < 700px) {
+  .statsGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/pages/PlanDetailPage.jsx
+++ b/src/pages/PlanDetailPage.jsx
@@ -17,6 +17,14 @@ const RHYTHM_DIVISORS = {
   annually: 12,
 }
 
+const RHYTHM_ORDER = ['monthly', 'quarterly', 'semi_annually', 'annually']
+
+const CATEGORY_COLORS = [
+  '#4e79a7', '#f28e2b', '#e15759', '#76b7b2', '#59a14f',
+  '#edc948', '#b07aa1', '#ff9da7', '#9c755f', '#bab0ac',
+  '#4dc9f6', '#f67019', '#537bc4', '#acc236', '#166a8f',
+]
+
 const emptyForm = {
   type: 'expense',
   category_id: '',
@@ -24,6 +32,50 @@ const emptyForm = {
   amount: '',
   payment_rhythm: 'monthly',
   note: '',
+}
+
+const DonutChart = ({ data }) => {
+  const size = 180
+  const cx = size / 2
+  const cy = size / 2
+  const r = size * 0.42
+  const innerR = size * 0.26
+  const total = data.reduce((s, d) => s + d.amount, 0)
+
+  if (data.length === 1) {
+    return (
+      <svg viewBox={`0 0 ${size} ${size}`} className={styles.donutSvg}>
+        <circle cx={cx} cy={cy} r={r} fill={data[0].color} />
+        <circle cx={cx} cy={cy} r={innerR} fill="var(--section-bg)" />
+      </svg>
+    )
+  }
+
+  let cumAngle = -Math.PI / 2
+  return (
+    <svg viewBox={`0 0 ${size} ${size}`} className={styles.donutSvg}>
+      {data.map((item) => {
+        const angle = (item.amount / total) * 2 * Math.PI
+        const startAngle = cumAngle
+        cumAngle += angle
+        const x1 = cx + r * Math.cos(startAngle)
+        const y1 = cy + r * Math.sin(startAngle)
+        const x2 = cx + r * Math.cos(cumAngle)
+        const y2 = cy + r * Math.sin(cumAngle)
+        const largeArc = angle > Math.PI ? 1 : 0
+        return (
+          <path
+            key={item.id}
+            d={`M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`}
+            fill={item.color}
+            stroke="var(--section-bg)"
+            strokeWidth="1.5"
+          />
+        )
+      })}
+      <circle cx={cx} cy={cy} r={innerR} fill="var(--section-bg)" />
+    </svg>
+  )
 }
 
 const PlanDetailPage = () => {
@@ -35,6 +87,12 @@ const PlanDetailPage = () => {
   const [categories, setCategories] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+
+  const [activeTab, setActiveTab] = useState('dashboard')
+  const [chartType, setChartType] = useState('expense')
+
+  const [sortField, setSortField] = useState('monthly_amount')
+  const [sortDir, setSortDir] = useState('desc')
 
   const [showModal, setShowModal] = useState(false)
   const [editingItem, setEditingItem] = useState(null)
@@ -74,6 +132,68 @@ const PlanDetailPage = () => {
     formData.amount && formData.payment_rhythm
       ? parseFloat(formData.amount) / RHYTHM_DIVISORS[formData.payment_rhythm]
       : null
+
+  const getCategoryBreakdown = (type) => {
+    const typeItems = items.filter((i) => i.type === type)
+    const total = typeItems.reduce((sum, i) => sum + i.monthly_amount, 0)
+    const byCat = {}
+    typeItems.forEach((item) => {
+      byCat[item.category_id] = (byCat[item.category_id] || 0) + item.monthly_amount
+    })
+    return Object.entries(byCat)
+      .map(([catId, amount]) => ({
+        id: parseInt(catId),
+        name: getCategoryName(parseInt(catId)),
+        amount,
+        percent: total > 0 ? (amount / total) * 100 : 0,
+      }))
+      .sort((a, b) => b.amount - a.amount)
+      .map((c, i) => ({ ...c, color: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }))
+  }
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortField(field)
+      setSortDir(['description', 'category', 'payment_rhythm'].includes(field) ? 'asc' : 'desc')
+    }
+  }
+
+  const getSortIcon = (field) => {
+    if (sortField !== field) return <span className={styles.sortIconInactive}> ↕</span>
+    return <span className={styles.sortIconActive}>{sortDir === 'asc' ? ' ↑' : ' ↓'}</span>
+  }
+
+  const getSortedItems = (sectionItems) => {
+    return [...sectionItems].sort((a, b) => {
+      let av, bv
+      switch (sortField) {
+        case 'description':
+          av = a.description.toLowerCase()
+          bv = b.description.toLowerCase()
+          break
+        case 'category':
+          av = getCategoryName(a.category_id).toLowerCase()
+          bv = getCategoryName(b.category_id).toLowerCase()
+          break
+        case 'amount':
+          av = a.amount
+          bv = b.amount
+          break
+        case 'payment_rhythm':
+          av = RHYTHM_ORDER.indexOf(a.payment_rhythm)
+          bv = RHYTHM_ORDER.indexOf(b.payment_rhythm)
+          break
+        default:
+          av = a.monthly_amount
+          bv = b.monthly_amount
+      }
+      if (av < bv) return sortDir === 'asc' ? -1 : 1
+      if (av > bv) return sortDir === 'asc' ? 1 : -1
+      return 0
+    })
+  }
 
   const handleOpenModal = (item = null) => {
     setEditingItem(item)
@@ -165,7 +285,6 @@ const PlanDetailPage = () => {
 
   const incomeItems = items.filter((i) => i.type === 'income')
   const expenseItems = items.filter((i) => i.type === 'expense')
-
   const incomeSum = incomeItems.reduce((sum, i) => sum + i.monthly_amount, 0)
   const expenseSum = expenseItems.reduce((sum, i) => sum + i.monthly_amount, 0)
 
@@ -206,6 +325,8 @@ const PlanDetailPage = () => {
       </div>
     ))
 
+  const breakdown = getCategoryBreakdown(chartType)
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -244,7 +365,14 @@ const PlanDetailPage = () => {
         </div>
         <div className={styles.statItem}>
           <span className={styles.statLabel}>Posten</span>
-          <span>{plan.budget_item_count}</span>
+          <span>
+            {incomeItems.length > 0 && expenseItems.length > 0
+              ? `${incomeItems.length} / ${expenseItems.length}`
+              : plan.budget_item_count}
+          </span>
+          {incomeItems.length > 0 && expenseItems.length > 0 && (
+            <span className={styles.statSubLabel}>Einnahmen / Ausgaben</span>
+          )}
         </div>
       </div>
 
@@ -256,41 +384,171 @@ const PlanDetailPage = () => {
           </button>
         </div>
       ) : (
-        <div className={styles.sections}>
-          {incomeItems.length > 0 && (
-            <section>
-              <h2 className={`${styles.sectionTitle} ${styles.sectionIncome}`}>
-                Einnahmen
-              </h2>
-              <div className={styles.itemList}>
-                {renderItemList(incomeItems)}
-                <div className={styles.sectionSum}>
-                  <span>Summe monatlich</span>
-                  <span className={styles.statIncome}>
-                    {formatCurrency(incomeSum)}
-                  </span>
-                </div>
+        <>
+          <div className={styles.tabs}>
+            <button
+              className={`${styles.tab} ${activeTab === 'dashboard' ? styles.tabActive : ''}`}
+              onClick={() => setActiveTab('dashboard')}
+            >
+              Übersicht
+            </button>
+            <button
+              className={`${styles.tab} ${activeTab === 'items' ? styles.tabActive : ''}`}
+              onClick={() => setActiveTab('items')}
+            >
+              Budget-Posten
+            </button>
+          </div>
+
+          {activeTab === 'dashboard' && (
+            <div className={styles.dashboard}>
+              {/* Top 5 Ausgabenkategorien - US-043 */}
+              <div className={styles.top5Section}>
+                <h3 className={styles.subTitle}>Top 5 Ausgabenkategorien</h3>
+                {getCategoryBreakdown('expense').length === 0 ? (
+                  <p className={styles.noData}>Keine Ausgaben vorhanden.</p>
+                ) : (
+                  <div className={styles.top5List}>
+                    {getCategoryBreakdown('expense').slice(0, 5).map((cat, i) => (
+                      <div key={cat.id} className={styles.top5Row}>
+                        <span className={styles.top5Rank}>{i + 1}</span>
+                        <span
+                          className={styles.colorDot}
+                          style={{ backgroundColor: cat.color }}
+                        />
+                        <span className={styles.top5Name}>{cat.name}</span>
+                        <span className={styles.top5Amount}>{formatCurrency(cat.amount)}/Mo</span>
+                        <span className={styles.breakdownPercent}>{cat.percent.toFixed(1)}%</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
-            </section>
+
+              {/* Vollständige Kategorieauswertung - US-041/042 */}
+              <div className={styles.chartToggle}>
+                <button
+                  className={`${styles.toggleBtn} ${chartType === 'expense' ? styles.toggleExpense : ''}`}
+                  onClick={() => setChartType('expense')}
+                >
+                  Ausgaben
+                </button>
+                <button
+                  className={`${styles.toggleBtn} ${chartType === 'income' ? styles.toggleIncome : ''}`}
+                  onClick={() => setChartType('income')}
+                >
+                  Einnahmen
+                </button>
+              </div>
+
+              {breakdown.length === 0 ? (
+                <div className={styles.noData}>
+                  Keine {chartType === 'expense' ? 'Ausgaben' : 'Einnahmen'} vorhanden.
+                </div>
+              ) : (
+                <div className={styles.dashboardGrid}>
+                  <div className={styles.breakdownSection}>
+                    <h3 className={styles.subTitle}>Nach Kategorie</h3>
+                    {breakdown.map((cat) => (
+                      <div key={cat.id} className={styles.breakdownRow}>
+                        <div className={styles.breakdownHeader}>
+                          <span
+                            className={styles.colorDot}
+                            style={{ backgroundColor: cat.color }}
+                          />
+                          <span className={styles.breakdownName}>{cat.name}</span>
+                          <span className={styles.breakdownAmount}>
+                            {formatCurrency(cat.amount)}/Mo
+                          </span>
+                          <span className={styles.breakdownPercent}>
+                            {cat.percent.toFixed(1)}%
+                          </span>
+                        </div>
+                        <div className={styles.breakdownBar}>
+                          <div
+                            className={styles.breakdownBarFill}
+                            style={{ width: `${cat.percent}%`, backgroundColor: cat.color }}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className={styles.chartSection}>
+                    <h3 className={styles.subTitle}>Verteilung</h3>
+                    <DonutChart data={breakdown} />
+                    <div className={styles.legend}>
+                      {breakdown.slice(0, 6).map((cat) => (
+                        <div key={cat.id} className={styles.legendItem}>
+                          <span
+                            className={styles.legendDot}
+                            style={{ backgroundColor: cat.color }}
+                          />
+                          <span className={styles.legendName}>{cat.name}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
           )}
 
-          {expenseItems.length > 0 && (
-            <section>
-              <h2 className={`${styles.sectionTitle} ${styles.sectionExpense}`}>
-                Ausgaben
-              </h2>
-              <div className={styles.itemList}>
-                {renderItemList(expenseItems)}
-                <div className={styles.sectionSum}>
-                  <span>Summe monatlich</span>
-                  <span className={styles.statExpenses}>
-                    {formatCurrency(expenseSum)}
-                  </span>
-                </div>
+          {activeTab === 'items' && (
+            <div className={styles.itemsView}>
+              <div className={styles.sortBar}>
+                <span className={styles.sortLabel}>Sortieren:</span>
+                {[
+                  { key: 'monthly_amount', label: 'Monatlich' },
+                  { key: 'amount', label: 'Betrag' },
+                  { key: 'description', label: 'Bezeichnung' },
+                  { key: 'category', label: 'Kategorie' },
+                  { key: 'payment_rhythm', label: 'Rhythmus' },
+                ].map(({ key, label }) => (
+                  <button
+                    key={key}
+                    className={`${styles.sortBtn} ${sortField === key ? styles.sortBtnActive : ''}`}
+                    onClick={() => handleSort(key)}
+                  >
+                    {label}{getSortIcon(key)}
+                  </button>
+                ))}
               </div>
-            </section>
+
+              <div className={styles.sections}>
+                {incomeItems.length > 0 && (
+                  <section>
+                    <h2 className={`${styles.sectionTitle} ${styles.sectionIncome}`}>
+                      Einnahmen
+                    </h2>
+                    <div className={styles.itemList}>
+                      {renderItemList(getSortedItems(incomeItems))}
+                      <div className={styles.sectionSum}>
+                        <span>Summe monatlich</span>
+                        <span className={styles.statIncome}>{formatCurrency(incomeSum)}</span>
+                      </div>
+                    </div>
+                  </section>
+                )}
+
+                {expenseItems.length > 0 && (
+                  <section>
+                    <h2 className={`${styles.sectionTitle} ${styles.sectionExpense}`}>
+                      Ausgaben
+                    </h2>
+                    <div className={styles.itemList}>
+                      {renderItemList(getSortedItems(expenseItems))}
+                      <div className={styles.sectionSum}>
+                        <span>Summe monatlich</span>
+                        <span className={styles.statExpenses}>{formatCurrency(expenseSum)}</span>
+                      </div>
+                    </div>
+                  </section>
+                )}
+              </div>
+            </div>
           )}
-        </div>
+        </>
       )}
 
       {showModal && (

--- a/src/pages/PlanDetailPage.module.css
+++ b/src/pages/PlanDetailPage.module.css
@@ -429,9 +429,329 @@
   margin-top: 0.5rem;
 }
 
+/* Stat sub-label (Einnahmen / Ausgaben count) */
+.statSubLabel {
+  font-size: 10px;
+  opacity: 0.5;
+}
+
+/* Tabs */
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 2px solid rgba(128, 128, 128, 0.15);
+}
+
+.tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  padding: 0.6rem 1.2rem;
+  font-family: "Roboto Mono", monospace;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  color: var(--text-color);
+  opacity: 0.5;
+  transition: opacity 0.15s, border-color 0.15s;
+}
+
+.tab:hover {
+  opacity: 0.8;
+}
+
+.tabActive {
+  opacity: 1;
+  border-bottom-color: var(--text-color);
+}
+
+/* Dashboard tab */
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.chartToggle {
+  display: flex;
+  gap: 0.5rem;
+  align-self: flex-start;
+}
+
+.toggleBtn {
+  background: none;
+  border: 2px solid rgba(128, 128, 128, 0.3);
+  border-radius: 20px;
+  padding: 0.4rem 1.1rem;
+  font-family: "Roboto Mono", monospace;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  color: var(--text-color);
+  opacity: 0.6;
+  transition: all 0.15s;
+}
+
+.toggleBtn:hover {
+  opacity: 0.85;
+}
+
+.toggleExpense {
+  opacity: 1;
+  border-color: #c62828;
+  color: #c62828;
+  background-color: rgba(198, 40, 40, 0.06);
+}
+
+.toggleIncome {
+  opacity: 1;
+  border-color: #2e7d32;
+  color: #2e7d32;
+  background-color: rgba(46, 125, 50, 0.06);
+}
+
+:global([data-theme="dark"]) .toggleExpense {
+  border-color: #ef9a9a;
+  color: #ef9a9a;
+  background-color: rgba(239, 154, 154, 0.08);
+}
+
+:global([data-theme="dark"]) .toggleIncome {
+  border-color: #66bb6a;
+  color: #66bb6a;
+  background-color: rgba(102, 187, 106, 0.08);
+}
+
+.dashboardGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.subTitle {
+  font-family: "Rubik", sans-serif;
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  opacity: 0.5;
+  margin: 0 0 1rem 0;
+}
+
+.breakdownSection {
+  background-color: var(--section-bg);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.breakdownRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.breakdownHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.colorDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.breakdownName {
+  flex: 1;
+  font-size: 14px;
+}
+
+.breakdownAmount {
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.breakdownPercent {
+  font-size: 12px;
+  opacity: 0.55;
+  min-width: 3.5rem;
+  text-align: right;
+}
+
+.breakdownBar {
+  height: 4px;
+  background-color: rgba(128, 128, 128, 0.15);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.breakdownBarFill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.chartSection {
+  background-color: var(--section-bg);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.donutSvg {
+  width: 160px;
+  height: 160px;
+}
+
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  width: 100%;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.legendDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.legendName {
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.noData {
+  padding: 2rem;
+  text-align: center;
+  opacity: 0.5;
+}
+
+/* Top 5 Ausgabenkategorien */
+.top5Section {
+  background-color: var(--section-bg);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.top5List {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.top5Row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.top5Rank {
+  font-size: 12px;
+  opacity: 0.4;
+  min-width: 1rem;
+  text-align: right;
+}
+
+.top5Name {
+  flex: 1;
+  font-size: 14px;
+}
+
+.top5Amount {
+  font-size: 13px;
+  font-weight: 700;
+  color: #c62828;
+}
+
+:global([data-theme="dark"]) .top5Amount {
+  color: #ef9a9a;
+}
+
+/* Items tab */
+.itemsView {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sortBar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.sortLabel {
+  font-size: 12px;
+  opacity: 0.5;
+  margin-right: 0.25rem;
+}
+
+.sortBtn {
+  background: none;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  border-radius: 20px;
+  padding: 0.3rem 0.8rem;
+  font-family: "Roboto Mono", monospace;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--text-color);
+  opacity: 0.6;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.sortBtn:hover {
+  opacity: 0.9;
+  background-color: rgba(128, 128, 128, 0.08);
+}
+
+.sortBtnActive {
+  opacity: 1;
+  border-color: var(--text-color);
+  background-color: rgba(128, 128, 128, 0.1);
+}
+
+.sortIconInactive {
+  opacity: 0.4;
+}
+
+.sortIconActive {
+  opacity: 1;
+}
+
 @media (width >= 800px) {
   .container {
     padding: 3rem;
+  }
+}
+
+@media (width < 700px) {
+  .dashboardGrid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
Add DashboardPage with two sections:

- Active plan selector (dropdown) with monthly stats grid (income, expenses, balance, item count)

- Plan comparison table for up to 3 plans side-by-side

Both selections are persisted in localStorage and survive page reload.