### PR TITLE
redesign: replace portfolio UI with professional SaaS design system

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,182 +5,68 @@ html, body, #root {
   padding: 0;
 }
 
-#root,
+#root {
+  display: flex;
+  min-height: 100vh;
+}
+
 #app-wrapper {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex: 1;
   min-height: 100vh;
-  height: 100%;
 }
 
 .app-content {
-  flex: 1 0 auto;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  margin-bottom: 54px;
+  flex: 1;
+  min-width: 0;
+  margin-left: 220px;
 }
 
-:root {
-  --background-color: #e8e5e0;
-  --btn-color: #222;
-  --btn-text-color: #fff;
-  --project-card-bg: #ffffff00;
-  --section-bg: #f8f7f4;
-  --section-header-bg: #d5d2cc;
-  --text-color: #222;
-  --form-text-color: #555;
-  --footer-text-color: #333;
-  --navlinks-bg: #dde8f0;
-  --navlinks-border: #bbc8d0;
-  --main-box-bg: #e8e5e0;
-  --input-bg: #fff;
-
-  --table-row-bg-light: #f2f1ee;
-  --table-row-bg-dark: #353a3e;
-  --table-border-light: #333;
-  --table-border-dark: #555;
+@media (width < 768px) {
+  .app-content {
+    margin-left: 0;
+    padding-top: 54px;
+  }
 }
 
-[data-theme="dark"] {
-  --background-color: #2d3035;
-  --btn-color: #fff;
-  --btn-text-color: #222;
-  --project-card-bg: #fff;
-  --section-bg: #363a3e;
-  --section-header-bg: #3f4347;
-  --text-color: #f0f0f0;
-  --form-text-color: #d0d0d0;
-  --footer-text-color: #aaaaaa;
-  --navlinks-bg: #2e363a;
-  --navlinks-border: #4a5258;
-  --main-box-bg: #363a3e;
-  --input-bg: #292c30;
-  --table-row-bg: var(--table-row-bg-dark);
-  --table-border: var(--table-border-dark);
-}
-
-[data-theme="light"] {
-  --table-row-bg: var(--table-row-bg-light);
-  --table-border: var(--table-border-light);
-}
-
-body {
-  font-family: "Roboto Mono", monospace;
-  background-color: var(--background-color);
-  color: var(--text-color);
-  margin: 0;
-}
-
-h1,
-h2,
-h3 {
-  font-family: "Rubik", sans-serif;
-  text-transform: uppercase;
-  color: var(--text-color);
-  margin: 0;
-  padding: 0;
-  letter-spacing: 0.04em;
-  font-weight: 800;
-}
-
-h1 {
-  font-size: 32px;
-}
-h2,
-h3 {
-  font-size: 20px;
-}
-
-p,
-td,
-th,
-label,
-input,
-button,
-span {
-  font-family: "Roboto Mono", monospace;
-  color: var(--text-color);
-  font-size: 16px;
-  font-weight: 400;
-  letter-spacing: 0.01em;
-}
-p {
-  font-weight: 300;
-}
-
-.sectionTitle {
-  margin-bottom: 30px;
-}
-
-.hover {
-  cursor: pointer;
-}
-
+/* Primary button - used globally */
 .btn {
-  font-family: "Roboto Mono", monospace;
-  font-weight: 700;
-  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  background: var(--accent);
+  color: var(--accent-text);
   border: none;
-  border-radius: 14px;
-  padding: 0.7rem 1.7rem;
+  border-radius: 7px;
+  padding: 0.55rem 1.2rem;
   cursor: pointer;
-  box-shadow: 0 1px 8px 0 rgba(80, 80, 80, 0.07);
-  background: #222;
-  color: #fff;
-  transition: background 0.18s, color 0.18s, transform 0.14s;
+  transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
+  white-space: nowrap;
+  text-decoration: none;
+  letter-spacing: 0.01em;
 }
 
 .btn:hover,
 .btn:focus {
-  background: #6b705c;
-  color: #fff;
+  background: var(--accent-hover);
+  color: var(--accent-text);
   outline: none;
-  transform: translateY(-1px) scale(1.01);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-[data-theme="dark"] .btn {
-  background: #fff;
-  color: #222;
-}
-[data-theme="dark"] .btn:hover,
-[data-theme="dark"] .btn:focus {
-  background: #6b705c;
-  color: #fff;
+.btn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
-@media (width >= 800px) {
-  #root {
-    gap: 100px;
-  }
-  h1 {
-    font-size: 40px;
-  }
-  h2,
-  h3 {
-    font-size: 24px;
-  }
-  p,
-  td,
-  th,
-  label,
-  input,
-  button,
-  span {
-    font-size: 20px;
-  }
-  .sectionTitle {
-    margin-bottom: 60px;
-  }
-}
-@media (width >= 1400px) {
-  #root {
-    gap: 200px;
-  }
-  h1 {
-    font-size: 48px;
-  }
-  .sectionTitle {
-    margin-bottom: 75px;
-  }
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { AuthProvider } from './contexts/AuthContext'
-import Navbar from './components/Navbar'
+import Sidebar from './components/Sidebar'
 import ProtectedRoute from './components/ProtectedRoute'
 import LoginPage from './pages/LoginPage'
 import RegisterPage from './pages/RegisterPage'
@@ -16,7 +16,7 @@ function App() {
     <ThemeProvider>
       <AuthProvider>
         <div id="app-wrapper">
-          <Navbar />
+          <Sidebar />
           <div className="app-content">
             <Routes>
               <Route path="/" element={<Navigate to="/login" replace />} />

--- a/src/components/Navbar.module.css
+++ b/src/components/Navbar.module.css
@@ -1,10 +1,11 @@
 .navbar {
-  background-color: var(--section-header-bg);
-  padding: 1rem 2rem;
+  background-color: var(--nav-bg);
+  padding: 0 1.5rem;
+  height: 54px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid var(--border-color);
   position: sticky;
   top: 0;
   z-index: 100;
@@ -12,100 +13,88 @@
 
 .navLeft {
   display: flex;
-  align-items: center;
-  gap: 2rem;
+  align-items: stretch;
+  gap: 0;
+  height: 100%;
 }
 
 .logo {
-  font-family: "Rubik", sans-serif;
-  font-size: 20px;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 700;
   color: var(--text-color);
   text-decoration: none;
+  letter-spacing: -0.01em;
+  padding-right: 1.5rem;
+  border-right: 1px solid var(--border-color);
+  margin-right: 0.25rem;
+  white-space: nowrap;
 }
 
 .navLinks {
   display: flex;
-  gap: 1rem;
-  align-items: center;
+  height: 100%;
+  align-items: stretch;
 }
 
 .navLink {
-  font-family: "Roboto Mono", monospace;
-  font-weight: 700;
-  font-size: 15px;
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
   text-decoration: none;
-  padding: 0.5rem 1.2rem;
-  border-radius: 14px;
-  box-shadow: 0 1px 8px 0 rgba(80, 80, 80, 0.07);
-  background: #222;
-  color: #fff;
-  transition: background 0.18s, color 0.18s, transform 0.14s;
+  padding: 0 0.875rem;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
 }
 
 .navLink:hover {
-  background: #6b705c;
-  color: #fff;
-  transform: translateY(-1px) scale(1.01);
+  color: var(--text-color);
 }
 
 .navRight {
   display: flex;
-  gap: 1rem;
+  gap: 0.625rem;
   align-items: center;
 }
 
 .themeToggle {
   background: none;
-  border: none;
-  padding: 0.4rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.35rem;
+  width: 32px;
+  height: 32px;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
-  color: var(--text-color);
-  transition: transform 0.2s;
+  color: var(--text-muted);
+  transition: background-color 0.15s, border-color 0.15s;
 }
 
 .themeToggle:hover {
-  transform: scale(1.15);
+  background-color: var(--background-color);
+  border-color: var(--border-hover);
 }
 
 .themeIcon {
-  width: 24px;
-  height: 24px;
+  width: 15px;
+  height: 15px;
   display: block;
-  color: var(--text-color);
+  opacity: 0.7;
 }
 
 :global([data-theme="dark"]) .themeIcon {
   filter: brightness(0) invert(1);
-}
-
-:global([data-theme="dark"]) .navLink {
-  background: #fff;
-  color: #222;
-}
-
-:global([data-theme="dark"]) .navLink:hover {
-  background: #6b705c;
-  color: #fff;
+  opacity: 0.6;
 }
 
 @media (width >= 800px) {
-  .logo {
-    font-size: 24px;
-  }
-
-  .navLink {
-    font-size: 16px;
-  }
-
-  .themeIcon {
-    width: 26px;
-    height: 26px;
+  .navbar {
+    padding: 0 2rem;
   }
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,106 @@
+import { NavLink, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+import { useTheme } from '../contexts/ThemeContext'
+import sunIcon from '../assets/sun.svg'
+import moonIcon from '../assets/moon.svg'
+import styles from './Sidebar.module.css'
+
+const Sidebar = () => {
+  const { isAuthenticated, logout, user } = useAuth()
+  const { theme, toggleTheme } = useTheme()
+  const navigate = useNavigate()
+
+  if (!isAuthenticated) return null
+
+  const handleLogout = async () => {
+    await logout()
+    navigate('/login')
+  }
+
+  const initial = user?.name
+    ? user.name.charAt(0).toUpperCase()
+    : user?.email?.charAt(0).toUpperCase() ?? '?'
+
+  const displayName = user?.name || user?.email || ''
+
+  return (
+    <aside className={styles.sidebar}>
+      <div className={styles.top}>
+        <div className={styles.logo}>
+          <span className={styles.logoMark}>FD</span>
+          <span className={styles.logoText}>Finance Dashboard</span>
+        </div>
+
+        <nav className={styles.nav}>
+          <NavLink
+            to="/dashboard"
+            className={({ isActive }) =>
+              `${styles.navLink} ${isActive ? styles.navLinkActive : ''}`
+            }
+          >
+            <span className={styles.navIcon}>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <rect x="1" y="1" width="6" height="6" rx="1" />
+                <rect x="9" y="1" width="6" height="6" rx="1" />
+                <rect x="1" y="9" width="6" height="6" rx="1" />
+                <rect x="9" y="9" width="6" height="6" rx="1" />
+              </svg>
+            </span>
+            Dashboard
+          </NavLink>
+          <NavLink
+            to="/plans"
+            className={({ isActive }) =>
+              `${styles.navLink} ${isActive ? styles.navLinkActive : ''}`
+            }
+          >
+            <span className={styles.navIcon}>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <path d="M2 4h12M2 8h8M2 12h10" strokeLinecap="round" />
+              </svg>
+            </span>
+            Pläne
+          </NavLink>
+          <NavLink
+            to="/categories"
+            className={({ isActive }) =>
+              `${styles.navLink} ${isActive ? styles.navLinkActive : ''}`
+            }
+          >
+            <span className={styles.navIcon}>
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="5" cy="5" r="3" />
+                <circle cx="11" cy="11" r="3" />
+                <path d="M11 2l2 2-2 2M5 10l-2 2 2 2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </span>
+            Kategorien
+          </NavLink>
+        </nav>
+      </div>
+
+      <div className={styles.bottom}>
+        <button onClick={toggleTheme} className={styles.themeToggle} aria-label="Design wechseln">
+          <img
+            src={theme === 'dark' ? sunIcon : moonIcon}
+            className={styles.themeIcon}
+            alt=""
+          />
+          {theme === 'dark' ? 'Heller Modus' : 'Dunkler Modus'}
+        </button>
+
+        <div className={styles.userSection}>
+          <div className={styles.userAvatar}>{initial}</div>
+          <div className={styles.userInfo}>
+            <span className={styles.userName}>{displayName}</span>
+            <button onClick={handleLogout} className={styles.logoutBtn}>
+              Abmelden
+            </button>
+          </div>
+        </div>
+      </div>
+    </aside>
+  )
+}
+
+export default Sidebar

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -1,0 +1,286 @@
+.sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: var(--sidebar-bg);
+  border-right: 1px solid var(--border-color);
+  overflow-y: auto;
+  z-index: 100;
+}
+
+.top {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* Logo */
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 1.25rem 1.25rem 1rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 0.5rem;
+}
+
+.logoMark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background-color: var(--accent);
+  color: var(--accent-text);
+  border-radius: 7px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+
+.logoText {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color);
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+}
+
+/* Navigation */
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0 0.625rem;
+}
+
+.navLink {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: background-color 0.12s, color 0.12s;
+  border-left: 2px solid transparent;
+}
+
+.navLink:hover {
+  background-color: var(--sidebar-hover);
+  color: var(--text-color);
+}
+
+.navLinkActive {
+  background-color: var(--sidebar-active-bg);
+  color: var(--accent);
+  font-weight: 600;
+  border-left-color: var(--accent);
+}
+
+.navIcon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.8;
+}
+
+.navIcon svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Bottom section */
+.bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 0.625rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.themeToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 7px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-align: left;
+  transition: background-color 0.12s, color 0.12s;
+}
+
+.themeToggle:hover {
+  background-color: var(--sidebar-hover);
+  color: var(--text-color);
+}
+
+.themeIcon {
+  width: 14px;
+  height: 14px;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+:global([data-theme="dark"]) .themeIcon {
+  filter: brightness(0) invert(1);
+  opacity: 0.5;
+}
+
+/* User section */
+.userSection {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 7px;
+}
+
+.userAvatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background-color: var(--accent);
+  color: var(--accent-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.userInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.userName {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.logoutBtn {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.12s;
+}
+
+.logoutBtn:hover {
+  color: var(--color-expense);
+}
+
+/* Mobile: horizontal bar at top */
+@media (width < 768px) {
+  .sidebar {
+    width: 100%;
+    height: auto;
+    position: fixed;
+    top: 0;
+    left: 0;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 1rem;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+    overflow: visible;
+  }
+
+  .top {
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+    flex: 1;
+    padding: 0.5rem 0;
+  }
+
+  .logo {
+    border-bottom: none;
+    padding: 0;
+    margin-bottom: 0;
+  }
+
+  .logoText {
+    display: none;
+  }
+
+  .nav {
+    flex-direction: row;
+    padding: 0;
+    gap: 0.125rem;
+  }
+
+  .navLink {
+    border-left: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 6px;
+    padding: 0.4rem 0.625rem;
+    font-size: 12px;
+  }
+
+  .navLinkActive {
+    border-left: none;
+    border-bottom-color: var(--accent);
+  }
+
+  .navIcon {
+    display: none;
+  }
+
+  .bottom {
+    flex-direction: row;
+    align-items: center;
+    border-top: none;
+    padding: 0.5rem 0;
+    gap: 0.5rem;
+  }
+
+  .themeToggle {
+    width: auto;
+    padding: 0.4rem;
+    font-size: 0;
+  }
+
+  .themeToggle .themeIcon {
+    opacity: 0.7;
+  }
+
+  .userSection {
+    padding: 0.25rem 0.5rem;
+  }
+
+  .userInfo {
+    display: none;
+  }
+}

--- a/src/pages/CategoriesPage.jsx
+++ b/src/pages/CategoriesPage.jsx
@@ -129,7 +129,7 @@ const CategoriesPage = () => {
                     className={styles.deleteBtn}
                     onClick={() => handleOpenDelete(cat)}
                   >
-                    Loschen
+                    Löschen
                   </button>
                 </div>
               )}
@@ -230,14 +230,14 @@ const CategoriesPage = () => {
         <div className={styles.modal} onClick={handleCloseDelete}>
           <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
             <div className={styles.modalHeader}>
-              <h2>Kategorie loschen</h2>
+              <h2>Kategorie löschen</h2>
               <button className={styles.closeBtn} onClick={handleCloseDelete}>
                 &times;
               </button>
             </div>
 
             <p className={styles.deleteText}>
-              Kategorie <strong>{deletingCategory.name}</strong> wirklich loschen?
+              Kategorie <strong>{deletingCategory.name}</strong> wirklich löschen?
             </p>
 
             {reassignOptions.length > 0 && (
@@ -252,13 +252,13 @@ const CategoriesPage = () => {
                   className={styles.input}
                   disabled={deleting}
                 >
-                  <option value="">-- Nicht umbuchen (Posten bleiben unveraendert)</option>
+                  <option value="">-- Nicht umbuchen (Posten bleiben unverändert)</option>
                   {reassignOptions.map((c) => (
                     <option key={c.id} value={c.id}>{c.name}</option>
                   ))}
                 </select>
                 <span className={styles.hint}>
-                  Falls Budget-Posten dieser Kategorie zugeordnet sind, musst du sie umbuchen oder zuerst loschen.
+                  Falls Budget-Posten dieser Kategorie zugeordnet sind, musst du sie umbuchen oder zuerst löschen.
                 </span>
               </div>
             )}
@@ -270,7 +270,7 @@ const CategoriesPage = () => {
                 Abbrechen
               </button>
               <button className={styles.deleteBtnModal} onClick={handleDelete} disabled={deleting}>
-                {deleting ? 'Wird geloscht...' : 'Loschen'}
+                {deleting ? 'Wird gelöscht...' : 'Löschen'}
               </button>
             </div>
           </div>

--- a/src/pages/CategoriesPage.module.css
+++ b/src/pages/CategoriesPage.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding: 2rem;
+  padding: 2rem 1.5rem;
   max-width: 800px;
   margin: 0 auto;
 }
@@ -8,64 +8,55 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 2rem;
-}
-
-.header h1 {
-  margin: 0;
+  margin-bottom: 1.5rem;
 }
 
 .sections {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.625rem;
 }
 
 .sectionTitle {
-  font-family: "Rubik", sans-serif;
-  font-size: 16px;
-  font-weight: 800;
+  font-size: 12px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
   margin: 0;
 }
 
 .expenseTitle {
-  color: #c62828;
+  color: var(--color-expense);
+  opacity: 0.85;
 }
 
 .incomeTitle {
-  color: #2e7d32;
-}
-
-:global([data-theme="dark"]) .expenseTitle {
-  color: #ef9a9a;
-}
-
-:global([data-theme="dark"]) .incomeTitle {
-  color: #66bb6a;
+  color: var(--color-income);
+  opacity: 0.85;
 }
 
 .categoryList {
   background-color: var(--section-bg);
-  border-radius: 12px;
+  border-radius: 9px;
+  border: 1px solid var(--border-color);
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-card);
 }
 
 .categoryRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.9rem 1.5rem;
-  border-bottom: 1px solid rgba(128, 128, 128, 0.12);
-  transition: background-color 0.15s;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+  transition: background-color 0.12s;
 }
 
 .categoryRow:last-child {
@@ -73,27 +64,28 @@
 }
 
 .categoryRow:hover {
-  background-color: rgba(128, 128, 128, 0.05);
+  background-color: var(--background-color);
 }
 
 .categoryInfo {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.625rem;
 }
 
 .categoryName {
+  font-size: 14px;
   font-weight: 500;
 }
 
 .systemBadge {
   font-size: 11px;
-  padding: 0.2rem 0.5rem;
-  border-radius: 6px;
-  background-color: rgba(128, 128, 128, 0.15);
-  color: var(--text-color);
-  opacity: 0.6;
-  font-weight: 400;
+  padding: 0.15rem 0.5rem;
+  border-radius: 20px;
+  background-color: var(--background-color);
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-weight: 500;
 }
 
 .categoryActions {
@@ -103,90 +95,109 @@
 }
 
 .editBtn {
-  background: none;
-  border: 1px solid rgba(128, 128, 128, 0.4);
-  border-radius: 8px;
-  padding: 0.3rem 0.7rem;
-  font-family: "Roboto Mono", monospace;
-  font-size: 12px;
+  background: var(--accent);
+  border: none;
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
-  color: var(--text-color);
-  transition: background-color 0.15s;
+  color: var(--accent-text);
+  transition: background-color 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
 .editBtn:hover {
-  background-color: rgba(128, 128, 128, 0.12);
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.editBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .deleteBtn {
-  background: none;
-  border: 1px solid rgba(198, 40, 40, 0.4);
-  border-radius: 8px;
-  padding: 0.3rem 0.7rem;
-  font-family: "Roboto Mono", monospace;
-  font-size: 12px;
+  background: var(--color-expense);
+  border: none;
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
-  color: #c62828;
-  transition: background-color 0.15s;
+  color: #ffffff;
+  transition: opacity 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
 .deleteBtn:hover {
-  background-color: rgba(198, 40, 40, 0.08);
+  opacity: 0.85;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(185, 28, 28, 0.25);
 }
 
-:global([data-theme="dark"]) .deleteBtn {
-  color: #ef9a9a;
-  border-color: rgba(239, 154, 154, 0.4);
+.deleteBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .emptySection {
-  padding: 1.5rem;
-  opacity: 0.6;
+  padding: 1.25rem;
+  color: var(--text-muted);
+  font-size: 13px;
   margin: 0;
 }
 
 .loading {
   text-align: center;
   padding: 3rem;
-  opacity: 0.7;
+  color: var(--text-muted);
 }
 
 .errorPage {
   text-align: center;
   padding: 3rem;
-  color: #c62828;
+  color: var(--color-expense);
 }
 
-/* Modal */
+/* Drawer (slide in from right) */
 .modal {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  background-color: rgba(0, 0, 0, 0.35);
   z-index: 1000;
-  padding: 1rem;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .modalContent {
   background-color: var(--section-bg);
-  padding: 2rem;
-  border-radius: 12px;
-  max-width: 480px;
   width: 100%;
-  max-height: 90vh;
+  max-width: 440px;
+  height: 100%;
   overflow-y: auto;
+  padding: 1.75rem 2rem;
+  border-left: 1px solid var(--border-color);
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.1);
+  animation: drawerIn 0.22s ease-out;
+}
+
+@keyframes drawerIn {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+:global([data-theme="dark"]) .modalContent {
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.4);
 }
 
 .modalHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.375rem;
 }
 
 .modalHeader h2 {
@@ -196,54 +207,63 @@
 .closeBtn {
   background: none;
   border: none;
-  font-size: 28px;
-  cursor: pointer;
-  color: var(--text-color);
+  font-size: 20px;
   line-height: 1;
-  padding: 0 0.25rem;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.closeBtn:hover {
+  color: var(--text-color);
+  background-color: var(--sidebar-hover);
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.125rem;
 }
 
 .formGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .label {
-  font-weight: 700;
-  font-size: 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color);
 }
 
 .optional {
   font-weight: 400;
-  opacity: 0.6;
+  color: var(--text-muted);
   font-size: 12px;
 }
 
 .hint {
   font-size: 12px;
-  opacity: 0.6;
+  color: var(--text-muted);
 }
 
 .input {
-  padding: 0.75rem;
-  border: 2px solid transparent;
-  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
   background-color: var(--input-bg);
   color: var(--text-color);
-  font-family: "Roboto Mono", monospace;
   font-size: 14px;
-  outline: 2px solid rgba(128, 128, 128, 0.3);
+  transition: border-color 0.15s, box-shadow 0.15s;
+  outline: none;
 }
 
 .input:focus {
-  outline: 2px solid var(--text-color);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
 }
 
 .typeToggle {
@@ -256,11 +276,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 0.6rem;
-  border-radius: 8px;
+  padding: 0.55rem;
+  border-radius: 7px;
   cursor: pointer;
-  font-size: 14px;
-  border: 2px solid rgba(128, 128, 128, 0.3);
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
   transition: all 0.15s;
 }
 
@@ -268,83 +290,112 @@
   display: none;
 }
 
+.typeOption:hover {
+  border-color: var(--border-hover);
+  color: var(--text-color);
+}
+
 .typeActiveExpense {
-  border-color: #c62828;
-  color: #c62828;
-  background-color: rgba(198, 40, 40, 0.08);
+  border-color: var(--color-expense);
+  color: var(--color-expense);
+  background-color: rgba(220, 38, 38, 0.06);
 }
 
 .typeActiveIncome {
-  border-color: #2e7d32;
-  color: #2e7d32;
-  background-color: rgba(46, 125, 50, 0.08);
+  border-color: var(--color-income);
+  color: var(--color-income);
+  background-color: rgba(22, 163, 74, 0.06);
 }
 
 :global([data-theme="dark"]) .typeActiveExpense {
-  border-color: #ef9a9a;
-  color: #ef9a9a;
-  background-color: rgba(239, 154, 154, 0.1);
+  border-color: var(--color-expense);
+  color: var(--color-expense);
+  background-color: rgba(248, 113, 113, 0.08);
 }
 
 :global([data-theme="dark"]) .typeActiveIncome {
-  border-color: #66bb6a;
-  color: #66bb6a;
-  background-color: rgba(102, 187, 106, 0.1);
+  border-color: var(--color-income);
+  color: var(--color-income);
+  background-color: rgba(52, 211, 153, 0.08);
 }
 
 .formActions {
   display: flex;
-  gap: 1rem;
+  gap: 0.625rem;
   justify-content: flex-end;
   margin-top: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+/* Secondary/ghost cancel button */
+.formActions :global(.btn):first-child {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+}
+
+.formActions :global(.btn):first-child:hover {
+  color: var(--text-color);
+  border-color: var(--border-hover);
+  background-color: var(--background-color);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .deleteText {
+  font-size: 14px;
+  color: var(--text-color);
+  line-height: 1.6;
   margin: 0 0 1.5rem 0;
 }
 
 .deleteBtnModal {
-  background-color: #c62828;
+  background-color: var(--color-expense);
   color: #fff;
   border: none;
-  border-radius: 14px;
-  padding: 0.6rem 1.4rem;
-  font-family: "Roboto Mono", monospace;
-  font-size: 14px;
-  font-weight: 700;
+  border-radius: 7px;
+  padding: 0.55rem 1.2rem;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: opacity 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
 .deleteBtnModal:hover {
-  background-color: #b71c1c;
+  opacity: 0.88;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(185, 28, 28, 0.25);
+}
+
+.deleteBtnModal:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .deleteBtnModal:disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
-}
-
-:global([data-theme="dark"]) .deleteBtnModal {
-  background-color: #ef9a9a;
-  color: #1a1a1a;
+  transform: none;
+  box-shadow: none;
 }
 
 .formError {
-  background-color: #ffebee;
-  color: #c62828;
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
-  margin-bottom: 1rem;
+  background-color: rgba(220, 38, 38, 0.06);
+  color: var(--color-expense);
+  border: 1px solid rgba(220, 38, 38, 0.15);
+  padding: 0.6rem 0.875rem;
+  border-radius: 6px;
+  font-size: 13px;
 }
 
 :global([data-theme="dark"]) .formError {
-  background-color: #5d1f1f;
-  color: #ffcdd2;
+  background-color: rgba(248, 113, 113, 0.08);
+  border-color: rgba(248, 113, 113, 0.2);
 }
 
 @media (width >= 800px) {
   .container {
-    padding: 3rem;
+    padding: 2.5rem 3rem;
   }
 }

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -81,7 +81,7 @@ const DashboardPage = () => {
               value={activePlanId ?? ''}
               onChange={handleSetActivePlan}
             >
-              <option value="">Plan auswahlen...</option>
+              <option value="">Plan auswählen...</option>
               {plans.map((p) => (
                 <option key={p.id} value={p.id}>{p.name}</option>
               ))}
@@ -91,22 +91,22 @@ const DashboardPage = () => {
 
         {plans.length === 0 ? (
           <div className={styles.emptyHint}>
-            Noch keine Plane vorhanden. <Link to="/plans">Plan erstellen</Link>
+            Noch keine Pläne vorhanden. <Link to="/plans">Plan erstellen</Link>
           </div>
         ) : activePlanId === null ? (
           <div className={styles.emptyHint}>
-            Wahle einen Plan aus dem Dropdown aus, um dessen Kennzahlen hier anzuzeigen.
+            Wähle einen Plan aus dem Dropdown aus, um dessen Kennzahlen hier anzuzeigen.
           </div>
         ) : activePlan === null ? (
           <div className={styles.emptyHint}>
-            Der zuletzt aktive Plan wurde geloscht. Bitte einen neuen Plan auswahlen.
+            Der zuletzt aktive Plan wurde gelöscht. Bitte einen neuen Plan auswählen.
           </div>
         ) : (
           <div className={styles.activePlanCard}>
             <div className={styles.activePlanHeader}>
               <span className={styles.activePlanName}>{activePlan.name}</span>
               <Link to={`/plans/${activePlan.id}`} className="btn">
-                Plan offnen
+                Plan öffnen
               </Link>
             </div>
             {activePlan.description && (
@@ -154,7 +154,7 @@ const DashboardPage = () => {
           <div className={styles.sectionHeader}>
             <h2>Plan-Vergleich</h2>
             {comparePlanIds.length >= 3 && (
-              <span className={styles.compareMaxHint}>Maximum erreicht (3 Plane)</span>
+              <span className={styles.compareMaxHint}>Maximum erreicht (3 Pläne)</span>
             )}
           </div>
 
@@ -181,7 +181,7 @@ const DashboardPage = () => {
 
           {comparePlans.length === 0 ? (
             <div className={styles.emptyHint}>
-              Wahle bis zu 3 Plane aus, um sie nebeneinander zu vergleichen.
+              Wähle bis zu 3 Pläne aus, um sie nebeneinander zu vergleichen.
             </div>
           ) : (
             <div className={styles.compareTableWrapper}>

--- a/src/pages/DashboardPage.module.css
+++ b/src/pages/DashboardPage.module.css
@@ -1,10 +1,10 @@
 .container {
-  padding: 2rem;
+  padding: 2rem 1.5rem;
   max-width: 1000px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 2rem;
 }
 
 .pageHeader h1 {
@@ -16,48 +16,46 @@
 .compareSection {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1rem;
 }
 
 .sectionHeader {
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  gap: 1rem;
   flex-wrap: wrap;
 }
 
 .sectionHeader h2 {
   margin: 0;
-  font-family: "Rubik", sans-serif;
-  font-size: 18px;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
 }
 
 /* Plan selector */
 .planSelector {
   padding: 0.45rem 0.75rem;
-  border-radius: 8px;
-  border: 2px solid rgba(128, 128, 128, 0.3);
+  border-radius: 7px;
+  border: 1px solid var(--border-color);
   background-color: var(--input-bg);
   color: var(--text-color);
-  font-family: "Roboto Mono", monospace;
   font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
   outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .planSelector:focus {
-  border-color: var(--text-color);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
 }
 
 /* Active plan card */
 .activePlanCard {
   background-color: var(--section-bg);
-  border-radius: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
   padding: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -72,75 +70,76 @@
 }
 
 .activePlanName {
-  font-family: "Rubik", sans-serif;
-  font-size: 20px;
-  font-weight: 800;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: var(--text-color);
 }
 
 .activePlanDescription {
   margin: 0;
-  opacity: 0.65;
-  font-size: 14px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 /* Stats grid */
 .statsGrid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-  margin-top: 0.25rem;
+  gap: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: var(--background-color);
 }
 
 .statBox {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
-  padding: 1rem;
-  background-color: var(--section-header-bg);
-  border-radius: 8px;
+  padding: 1rem 1.125rem;
+  background-color: var(--section-bg);
+  border-right: 1px solid var(--border-color);
+}
+
+.statBox:last-child {
+  border-right: none;
 }
 
 .statLabel {
   font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  opacity: 0.55;
+  color: var(--text-muted);
 }
 
 .statValue {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
 
 .statSub {
   font-size: 11px;
-  opacity: 0.45;
+  color: var(--text-subtle);
 }
 
 .statIncome {
-  color: #2e7d32;
+  color: var(--color-income);
 }
 
 .statExpenses {
-  color: #c62828;
+  color: var(--color-expense);
 }
 
 .statPositive {
-  color: #2e7d32;
+  color: var(--color-income);
 }
 
 .statNegative {
-  color: #c62828;
-}
-
-:global([data-theme="dark"]) .statIncome,
-:global([data-theme="dark"]) .statPositive {
-  color: #66bb6a;
-}
-
-:global([data-theme="dark"]) .statExpenses,
-:global([data-theme="dark"]) .statNegative {
-  color: #ef9a9a;
+  color: var(--color-expense);
 }
 
 /* Compare picker */
@@ -154,79 +153,86 @@
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.4rem 0.9rem;
-  border: 1px solid rgba(128, 128, 128, 0.35);
+  padding: 0.35rem 0.875rem;
+  border: 1px solid var(--border-color);
   border-radius: 20px;
   font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.15s, border-color 0.15s;
+  transition: border-color 0.15s, background-color 0.15s, color 0.15s;
   user-select: none;
+  color: var(--text-muted);
 }
 
 .compareOption:hover {
-  background-color: rgba(128, 128, 128, 0.08);
+  border-color: var(--border-hover);
+  color: var(--text-color);
+  background-color: var(--background-color);
 }
 
 .compareOption input[type="checkbox"] {
-  accent-color: var(--text-color);
+  accent-color: var(--accent);
   cursor: pointer;
+  width: 13px;
+  height: 13px;
 }
 
 .compareOptionDisabled {
-  opacity: 0.4;
+  opacity: 0.38;
   cursor: not-allowed;
-}
-
-.compareOptionDisabled:hover {
-  background-color: transparent;
+  pointer-events: none;
 }
 
 .compareMaxHint {
   font-size: 12px;
-  opacity: 0.55;
+  color: var(--text-muted);
+  padding: 0.35rem 0.5rem;
 }
 
 /* Compare table */
 .compareTableWrapper {
   overflow-x: auto;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-radius: 9px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-card);
 }
 
 .compareTable {
   width: 100%;
   border-collapse: collapse;
   background-color: var(--section-bg);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .compareTh {
-  padding: 0.9rem 1.25rem;
+  padding: 0.875rem 1.25rem;
   text-align: left;
-  font-family: "Rubik", sans-serif;
   font-size: 13px;
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  border-bottom: 2px solid rgba(128, 128, 128, 0.15);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-color);
   white-space: nowrap;
+  color: var(--text-color);
+  letter-spacing: -0.01em;
 }
 
 .compareRowLabel {
-  padding: 0.8rem 1.25rem;
-  font-size: 12px;
+  padding: 0.75rem 1.25rem;
+  font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  opacity: 0.55;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
   white-space: nowrap;
   vertical-align: middle;
+  background-color: var(--background-color);
 }
 
 .compareTd {
-  padding: 0.8rem 1.25rem;
-  font-weight: 700;
-  border-bottom: 1px solid rgba(128, 128, 128, 0.1);
+  padding: 0.75rem 1.25rem;
+  font-weight: 600;
+  border-bottom: 1px solid var(--border-color);
   vertical-align: middle;
+  font-variant-numeric: tabular-nums;
 }
 
 .compareTable tbody tr:last-child .compareTd,
@@ -236,76 +242,78 @@
 
 .compareBalanceRow .compareTd,
 .compareBalanceRow .compareRowLabel {
-  border-top: 2px solid rgba(128, 128, 128, 0.15);
-  border-bottom: 2px solid rgba(128, 128, 128, 0.15);
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+  background-color: var(--background-color);
 }
 
 .compareValueIncome {
-  color: #2e7d32;
+  color: var(--color-income);
 }
 
 .compareValueExpenses {
-  color: #c62828;
+  color: var(--color-expense);
 }
 
 .compareValuePositive {
-  color: #2e7d32;
+  color: var(--color-income);
 }
 
 .compareValueNegative {
-  color: #c62828;
-}
-
-:global([data-theme="dark"]) .compareValueIncome,
-:global([data-theme="dark"]) .compareValuePositive {
-  color: #66bb6a;
-}
-
-:global([data-theme="dark"]) .compareValueExpenses,
-:global([data-theme="dark"]) .compareValueNegative {
-  color: #ef9a9a;
+  color: var(--color-expense);
 }
 
 /* Utility */
 .emptyHint {
-  padding: 1.5rem;
-  opacity: 0.65;
-  font-size: 14px;
+  padding: 1.25rem 1.5rem;
+  color: var(--text-muted);
+  font-size: 13px;
   background-color: var(--section-bg);
-  border-radius: 10px;
+  border-radius: 9px;
+  border: 1px solid var(--border-color);
+  line-height: 1.6;
 }
 
 .emptyHint a {
-  color: var(--text-color);
-  font-weight: 700;
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.emptyHint a:hover {
   text-decoration: underline;
 }
 
 .loading {
   text-align: center;
   padding: 3rem;
-  opacity: 0.7;
+  color: var(--text-muted);
 }
 
 .error {
   text-align: center;
   padding: 3rem;
-  color: #c62828;
-}
-
-:global([data-theme="dark"]) .error {
-  color: #ef9a9a;
+  color: var(--color-expense);
 }
 
 /* Responsive */
 @media (width >= 800px) {
   .container {
-    padding: 3rem;
+    padding: 2.5rem 3rem;
   }
 }
 
 @media (width < 700px) {
   .statsGrid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .statBox {
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .statBox:nth-child(2n) {
+    border-right: none;
   }
 }

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -19,7 +19,7 @@ const LoginPage = () => {
     const result = await login({ email, password })
 
     if (result.success) {
-      navigate('/plans')
+      navigate('/dashboard')
     } else {
       setError(result.error || 'Anmeldung fehlgeschlagen.')
     }

--- a/src/pages/PlanDetailPage.module.css
+++ b/src/pages/PlanDetailPage.module.css
@@ -1,5 +1,5 @@
 .container {
-  padding: 2rem;
+  padding: 2rem 1.5rem;
   max-width: 1000px;
   margin: 0 auto;
 }
@@ -7,25 +7,33 @@
 .header {
   display: flex;
   align-items: flex-start;
-  gap: 1.5rem;
-  margin-bottom: 2rem;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
 }
 
 .backBtn {
-  background: none;
+  background: var(--accent);
   border: none;
+  border-radius: 7px;
   cursor: pointer;
-  font-family: "Roboto Mono", monospace;
-  font-size: 15px;
-  color: var(--text-color);
-  opacity: 0.7;
-  padding: 0.25rem 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent-text);
+  padding: 0.4rem 0.875rem;
   white-space: nowrap;
-  transition: opacity 0.2s;
+  transition: background-color 0.15s, transform 0.15s, box-shadow 0.15s;
+  flex-shrink: 0;
 }
 
 .backBtn:hover {
-  opacity: 1;
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.backBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .headerTitle {
@@ -33,117 +41,123 @@
 }
 
 .headerTitle h1 {
-  margin: 0 0 0.25rem 0;
+  margin: 0 0 0.2rem 0;
 }
 
 .description {
-  opacity: 0.7;
+  color: var(--text-muted);
+  font-size: 13px;
   margin: 0;
 }
 
+/* Stats bar */
 .statsBar {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
+  gap: 0;
   background-color: var(--section-bg);
-  border-radius: 12px;
-  padding: 1.5rem;
-  margin-bottom: 2rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-radius: 9px;
+  border: 1px solid var(--border-color);
+  overflow: hidden;
+  margin-bottom: 1.75rem;
+  box-shadow: var(--shadow-card);
 }
 
 .statItem {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
+  padding: 1.125rem 1.25rem;
+  border-right: 1px solid var(--border-color);
+}
+
+.statItem:last-child {
+  border-right: none;
 }
 
 .statLabel {
-  font-size: 12px;
-  opacity: 0.6;
+  font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
 }
 
 .statIncome {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
-  color: #2e7d32;
+  color: var(--color-income);
+  font-variant-numeric: tabular-nums;
 }
 
 .statExpenses {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
-  color: #c62828;
+  color: var(--color-expense);
+  font-variant-numeric: tabular-nums;
 }
 
 .statPositive {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
-  color: #2e7d32;
+  color: var(--color-income);
+  font-variant-numeric: tabular-nums;
 }
 
 .statNegative {
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
-  color: #c62828;
+  color: var(--color-expense);
+  font-variant-numeric: tabular-nums;
 }
 
-:global([data-theme="dark"]) .statIncome,
-:global([data-theme="dark"]) .statPositive {
-  color: #66bb6a;
+.statSubLabel {
+  font-size: 10px;
+  color: var(--text-subtle);
+  margin-top: 0.1rem;
 }
 
-:global([data-theme="dark"]) .statExpenses,
-:global([data-theme="dark"]) .statNegative {
-  color: #ef9a9a;
-}
-
+/* Sections */
 .sections {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
 }
 
 .sectionTitle {
-  font-family: "Rubik", sans-serif;
-  font-size: 16px;
-  font-weight: 800;
+  font-size: 12px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin: 0 0 0.75rem 0;
+  letter-spacing: 0.07em;
+  margin: 0 0 0.625rem 0;
+  color: var(--text-muted);
 }
 
 .sectionIncome {
-  color: #2e7d32;
+  color: var(--color-income);
+  opacity: 0.85;
 }
 
 .sectionExpense {
-  color: #c62828;
-}
-
-:global([data-theme="dark"]) .sectionIncome {
-  color: #66bb6a;
-}
-
-:global([data-theme="dark"]) .sectionExpense {
-  color: #ef9a9a;
+  color: var(--color-expense);
+  opacity: 0.85;
 }
 
 .itemList {
   background-color: var(--section-bg);
-  border-radius: 12px;
+  border-radius: 9px;
+  border: 1px solid var(--border-color);
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-card);
 }
 
 .itemRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem 1.5rem;
-  border-bottom: 1px solid rgba(128, 128, 128, 0.12);
-  transition: background-color 0.15s;
+  padding: 0.875rem 1.25rem;
+  border-bottom: 1px solid var(--border-color);
+  transition: background-color 0.12s;
 }
 
 .itemRow:last-child {
@@ -151,7 +165,7 @@
 }
 
 .itemRow:hover {
-  background-color: rgba(128, 128, 128, 0.05);
+  background-color: var(--background-color);
 }
 
 .itemInfo {
@@ -161,394 +175,294 @@
 }
 
 .itemDescription {
+  font-size: 14px;
   font-weight: 500;
 }
 
 .itemMeta {
   font-size: 12px;
-  opacity: 0.55;
+  color: var(--text-muted);
+}
+
+.itemNote {
+  font-size: 12px;
+  color: var(--text-subtle);
+  font-style: italic;
 }
 
 .itemAmounts {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.2rem;
+  gap: 0.15rem;
+}
+
+.itemAmount {
+  font-size: 14px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.itemMonthly {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
 }
 
 .itemActions {
   display: flex;
   gap: 0.5rem;
-  margin-left: 1rem;
+  margin-left: 1.5rem;
   flex-shrink: 0;
 }
 
 .editBtn {
-  background: none;
-  border: 1px solid rgba(128, 128, 128, 0.4);
-  border-radius: 8px;
-  padding: 0.3rem 0.7rem;
-  font-family: "Roboto Mono", monospace;
-  font-size: 12px;
+  background: var(--accent);
+  border: none;
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
-  color: var(--text-color);
-  transition: background-color 0.15s;
+  color: var(--accent-text);
+  transition: background-color 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
 .editBtn:hover {
-  background-color: rgba(128, 128, 128, 0.12);
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.editBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .deleteBtn {
-  background: none;
-  border: 1px solid rgba(198, 40, 40, 0.4);
-  border-radius: 8px;
-  padding: 0.3rem 0.7rem;
-  font-family: "Roboto Mono", monospace;
-  font-size: 12px;
+  background: var(--color-expense);
+  border: none;
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
-  color: #c62828;
-  transition: background-color 0.15s;
+  color: #ffffff;
+  transition: opacity 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
 .deleteBtn:hover {
-  background-color: rgba(198, 40, 40, 0.08);
+  opacity: 0.85;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(185, 28, 28, 0.25);
 }
 
-:global([data-theme="dark"]) .deleteBtn {
-  color: #ef9a9a;
-  border-color: rgba(239, 154, 154, 0.4);
-}
-
-.itemAmount {
-  font-weight: 700;
-}
-
-.itemMonthly {
-  font-size: 12px;
-  opacity: 0.55;
-}
-
-.itemNote {
-  font-size: 12px;
-  opacity: 0.5;
-  font-style: italic;
+.deleteBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .sectionSum {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.9rem 1.5rem;
-  border-top: 2px solid rgba(128, 128, 128, 0.15);
-  font-weight: 700;
-  font-size: 14px;
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background-color: var(--background-color);
 }
 
 .empty {
   text-align: center;
   padding: 4rem 2rem;
-  opacity: 0.75;
+  color: var(--text-muted);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .loading {
   text-align: center;
   padding: 3rem;
-  opacity: 0.7;
+  color: var(--text-muted);
 }
 
 .errorPage {
   text-align: center;
   padding: 3rem;
-  color: #c62828;
-}
-
-/* Modal */
-.modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-  padding: 1rem;
-}
-
-.modalContent {
-  background-color: var(--section-bg);
-  padding: 2rem;
-  border-radius: 12px;
-  max-width: 560px;
-  width: 100%;
-  max-height: 90vh;
-  overflow-y: auto;
-}
-
-.modalHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.5rem;
-}
-
-.closeBtn {
-  background: none;
-  border: none;
-  font-size: 28px;
-  cursor: pointer;
-  color: var(--text-color);
-  line-height: 1;
-  padding: 0 0.25rem;
-}
-
-.form {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.formRow {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-}
-
-.formGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.label {
-  font-weight: 700;
-  font-size: 14px;
-}
-
-.optional {
-  font-weight: 400;
-  opacity: 0.6;
-  font-size: 12px;
-}
-
-.input {
-  padding: 0.75rem;
-  border: 2px solid transparent;
-  border-radius: 8px;
-  background-color: var(--input-bg);
-  color: var(--text-color);
-  font-family: "Roboto Mono", monospace;
-  font-size: 14px;
-  outline: 2px solid rgba(128, 128, 128, 0.3);
-}
-
-.input:focus {
-  outline: 2px solid var(--text-color);
-}
-
-.textarea {
-  min-height: 80px;
-  resize: vertical;
-}
-
-.monthlyPreview {
-  font-size: 13px;
-  opacity: 0.7;
-  margin-top: 0.25rem;
-}
-
-.typeToggle {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.typeOption {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 0.6rem;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 14px;
-  border: 2px solid rgba(128, 128, 128, 0.3);
-  transition: all 0.15s;
-}
-
-.typeOption input {
-  display: none;
-}
-
-.typeActive {
-  border-color: #c62828;
-  color: #c62828;
-  background-color: rgba(198, 40, 40, 0.08);
-}
-
-.typeActiveIncome {
-  border-color: #2e7d32;
-  color: #2e7d32;
-  background-color: rgba(46, 125, 50, 0.08);
-}
-
-:global([data-theme="dark"]) .typeActive {
-  border-color: #ef9a9a;
-  color: #ef9a9a;
-  background-color: rgba(239, 154, 154, 0.1);
-}
-
-:global([data-theme="dark"]) .typeActiveIncome {
-  border-color: #66bb6a;
-  color: #66bb6a;
-  background-color: rgba(102, 187, 106, 0.1);
-}
-
-.formError {
-  background-color: #ffebee;
-  color: #c62828;
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
-}
-
-:global([data-theme="dark"]) .formError {
-  background-color: #5d1f1f;
-  color: #ffcdd2;
-}
-
-.formActions {
-  display: flex;
-  gap: 1rem;
-  justify-content: flex-end;
-  margin-top: 0.5rem;
-}
-
-/* Stat sub-label (Einnahmen / Ausgaben count) */
-.statSubLabel {
-  font-size: 10px;
-  opacity: 0.5;
+  color: var(--color-expense);
 }
 
 /* Tabs */
 .tabs {
   display: flex;
-  gap: 0.25rem;
   margin-bottom: 1.5rem;
-  border-bottom: 2px solid rgba(128, 128, 128, 0.15);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .tab {
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
-  margin-bottom: -2px;
-  padding: 0.6rem 1.2rem;
-  font-family: "Roboto Mono", monospace;
-  font-size: 14px;
-  font-weight: 700;
+  margin-bottom: -1px;
+  padding: 0.625rem 1rem;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
-  color: var(--text-color);
-  opacity: 0.5;
-  transition: opacity 0.15s, border-color 0.15s;
+  color: var(--text-muted);
+  transition: color 0.15s, border-color 0.15s;
 }
 
 .tab:hover {
-  opacity: 0.8;
+  color: var(--text-color);
 }
 
 .tabActive {
-  opacity: 1;
-  border-bottom-color: var(--text-color);
+  color: var(--text-color);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
 }
 
-/* Dashboard tab */
+/* Sort bar */
+.itemsView {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.sortBar {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+.sortLabel {
+  font-size: 12px;
+  color: var(--text-subtle);
+  margin-right: 0.125rem;
+}
+
+.sortBtn {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 0.275rem 0.75rem;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--text-muted);
+  transition: border-color 0.15s, color 0.15s, background-color 0.15s, transform 0.15s;
+  white-space: nowrap;
+}
+
+.sortBtn:hover {
+  border-color: var(--border-hover);
+  color: var(--text-color);
+  transform: translateY(-1px);
+}
+
+.sortBtn:active {
+  transform: translateY(0);
+}
+
+.sortBtnActive {
+  border-color: var(--accent);
+  color: var(--accent);
+  background-color: var(--accent-subtle);
+}
+
+.sortIconInactive {
+  opacity: 0.3;
+}
+
+.sortIconActive {
+  opacity: 0.8;
+}
+
+/* Dashboard overview */
 .dashboard {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .chartToggle {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.375rem;
   align-self: flex-start;
 }
 
 .toggleBtn {
   background: none;
-  border: 2px solid rgba(128, 128, 128, 0.3);
+  border: 1px solid var(--border-color);
   border-radius: 20px;
-  padding: 0.4rem 1.1rem;
-  font-family: "Roboto Mono", monospace;
-  font-size: 13px;
-  font-weight: 700;
+  padding: 0.3rem 1rem;
+  font-size: 12px;
+  font-weight: 600;
   cursor: pointer;
-  color: var(--text-color);
-  opacity: 0.6;
-  transition: all 0.15s;
+  color: var(--text-muted);
+  transition: border-color 0.15s, color 0.15s, background-color 0.15s, transform 0.15s;
 }
 
 .toggleBtn:hover {
-  opacity: 0.85;
+  border-color: var(--border-hover);
+  color: var(--text-color);
+  transform: translateY(-1px);
+}
+
+.toggleBtn:active {
+  transform: translateY(0);
 }
 
 .toggleExpense {
-  opacity: 1;
-  border-color: #c62828;
-  color: #c62828;
-  background-color: rgba(198, 40, 40, 0.06);
+  border-color: var(--color-expense);
+  color: var(--color-expense);
+  background-color: rgba(220, 38, 38, 0.06);
 }
 
 .toggleIncome {
-  opacity: 1;
-  border-color: #2e7d32;
-  color: #2e7d32;
-  background-color: rgba(46, 125, 50, 0.06);
+  border-color: var(--color-income);
+  color: var(--color-income);
+  background-color: rgba(22, 163, 74, 0.06);
 }
 
 :global([data-theme="dark"]) .toggleExpense {
-  border-color: #ef9a9a;
-  color: #ef9a9a;
-  background-color: rgba(239, 154, 154, 0.08);
+  background-color: rgba(248, 113, 113, 0.08);
 }
 
 :global([data-theme="dark"]) .toggleIncome {
-  border-color: #66bb6a;
-  color: #66bb6a;
-  background-color: rgba(102, 187, 106, 0.08);
+  background-color: rgba(52, 211, 153, 0.08);
 }
 
 .dashboardGrid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1.5rem;
+  gap: 1rem;
   align-items: start;
 }
 
 .subTitle {
-  font-family: "Rubik", sans-serif;
-  font-size: 13px;
-  font-weight: 800;
+  font-size: 11px;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  opacity: 0.5;
-  margin: 0 0 1rem 0;
+  color: var(--text-muted);
+  margin: 0 0 0.875rem 0;
 }
 
 .breakdownSection {
   background-color: var(--section-bg);
-  border-radius: 12px;
-  padding: 1.25rem 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-radius: 9px;
+  border: 1px solid var(--border-color);
+  padding: 1.125rem 1.25rem;
+  box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.625rem;
 }
 
 .breakdownRow {
@@ -564,32 +478,34 @@
 }
 
 .colorDot {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
 .breakdownName {
   flex: 1;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .breakdownAmount {
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .breakdownPercent {
   font-size: 12px;
-  opacity: 0.55;
-  min-width: 3.5rem;
+  color: var(--text-muted);
+  min-width: 3.25rem;
   text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .breakdownBar {
-  height: 4px;
-  background-color: rgba(128, 128, 128, 0.15);
+  height: 3px;
+  background-color: var(--border-color);
   border-radius: 2px;
   overflow: hidden;
 }
@@ -602,24 +518,25 @@
 
 .chartSection {
   background-color: var(--section-bg);
-  border-radius: 12px;
-  padding: 1.25rem 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-radius: 9px;
+  border: 1px solid var(--border-color);
+  padding: 1.125rem 1.25rem;
+  box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: 0.875rem;
 }
 
 .donutSvg {
-  width: 160px;
-  height: 160px;
+  width: 148px;
+  height: 148px;
 }
 
 .legend {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.35rem;
   width: 100%;
 }
 
@@ -630,122 +547,272 @@
 }
 
 .legendDot {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
 }
 
 .legendName {
   font-size: 12px;
-  opacity: 0.75;
+  color: var(--text-muted);
 }
 
 .noData {
   padding: 2rem;
   text-align: center;
-  opacity: 0.5;
+  color: var(--text-muted);
+  font-size: 13px;
 }
 
-/* Top 5 Ausgabenkategorien */
+/* Top 5 */
 .top5Section {
   background-color: var(--section-bg);
-  border-radius: 12px;
-  padding: 1.25rem 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border-radius: 9px;
+  border: 1px solid var(--border-color);
+  padding: 1.125rem 1.25rem;
+  box-shadow: var(--shadow-card);
 }
 
 .top5List {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.5rem;
   margin-top: 0.5rem;
 }
 
 .top5Row {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.55rem;
 }
 
 .top5Rank {
-  font-size: 12px;
-  opacity: 0.4;
+  font-size: 11px;
+  color: var(--text-subtle);
   min-width: 1rem;
   text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .top5Name {
   flex: 1;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .top5Amount {
   font-size: 13px;
-  font-weight: 700;
-  color: #c62828;
+  font-weight: 600;
+  color: var(--color-expense);
+  font-variant-numeric: tabular-nums;
 }
 
-:global([data-theme="dark"]) .top5Amount {
-  color: #ef9a9a;
+/* Drawer (slide in from right) */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
 }
 
-/* Items tab */
-.itemsView {
+.modalContent {
+  background-color: var(--section-bg);
+  width: 100%;
+  max-width: 520px;
+  height: 100%;
+  overflow-y: auto;
+  padding: 1.75rem 2rem;
+  border-left: 1px solid var(--border-color);
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.1);
+  animation: drawerIn 0.22s ease-out;
+}
+
+@keyframes drawerIn {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+:global([data-theme="dark"]) .modalContent {
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.4);
+}
+
+.modalHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.closeBtn:hover {
+  color: var(--text-color);
+  background-color: var(--sidebar-hover);
+}
+
+.form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.125rem;
 }
 
-.sortBar {
+.formRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.875rem;
+}
+
+.formGroup {
   display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
-.sortLabel {
-  font-size: 12px;
-  opacity: 0.5;
-  margin-right: 0.25rem;
-}
-
-.sortBtn {
-  background: none;
-  border: 1px solid rgba(128, 128, 128, 0.3);
-  border-radius: 20px;
-  padding: 0.3rem 0.8rem;
-  font-family: "Roboto Mono", monospace;
-  font-size: 12px;
-  cursor: pointer;
+.label {
+  font-size: 13px;
+  font-weight: 600;
   color: var(--text-color);
-  opacity: 0.6;
+}
+
+.optional {
+  font-weight: 400;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.input {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
+  background-color: var(--input-bg);
+  color: var(--text-color);
+  font-size: 14px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  outline: none;
+}
+
+.input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
+.textarea {
+  min-height: 76px;
+  resize: vertical;
+}
+
+.monthlyPreview {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 0.2rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.typeToggle {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.typeOption {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.55rem;
+  border-radius: 7px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
   transition: all 0.15s;
-  white-space: nowrap;
 }
 
-.sortBtn:hover {
-  opacity: 0.9;
-  background-color: rgba(128, 128, 128, 0.08);
+.typeOption input {
+  display: none;
 }
 
-.sortBtnActive {
-  opacity: 1;
-  border-color: var(--text-color);
-  background-color: rgba(128, 128, 128, 0.1);
+.typeOption:hover {
+  border-color: var(--border-hover);
+  color: var(--text-color);
 }
 
-.sortIconInactive {
-  opacity: 0.4;
+.typeActive {
+  border-color: var(--color-expense);
+  color: var(--color-expense);
+  background-color: rgba(220, 38, 38, 0.06);
 }
 
-.sortIconActive {
-  opacity: 1;
+.typeActiveIncome {
+  border-color: var(--color-income);
+  color: var(--color-income);
+  background-color: rgba(22, 163, 74, 0.06);
+}
+
+:global([data-theme="dark"]) .typeActive {
+  background-color: rgba(248, 113, 113, 0.08);
+}
+
+:global([data-theme="dark"]) .typeActiveIncome {
+  background-color: rgba(52, 211, 153, 0.08);
+}
+
+.formError {
+  background-color: rgba(220, 38, 38, 0.06);
+  color: var(--color-expense);
+  border: 1px solid rgba(220, 38, 38, 0.15);
+  padding: 0.6rem 0.875rem;
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+:global([data-theme="dark"]) .formError {
+  background-color: rgba(248, 113, 113, 0.08);
+  border-color: rgba(248, 113, 113, 0.2);
+}
+
+.formActions {
+  display: flex;
+  gap: 0.625rem;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+/* Secondary/ghost cancel button */
+.formActions :global(.btn):first-child {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+}
+
+.formActions :global(.btn):first-child:hover {
+  color: var(--text-color);
+  border-color: var(--border-hover);
+  background-color: var(--background-color);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 @media (width >= 800px) {
   .container {
-    padding: 3rem;
+    padding: 2.5rem 3rem;
   }
 }
 
@@ -758,6 +825,11 @@
 @media (width < 600px) {
   .statsBar {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .statItem {
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
   }
 
   .formRow {

--- a/src/pages/PlansPage.jsx
+++ b/src/pages/PlansPage.jsx
@@ -125,11 +125,31 @@ const PlansPage = () => {
       ) : (
         <div className={styles.plansList}>
           {plans.map((plan) => (
-            <div key={plan.id} className={styles.planCard}>
-              <div className={styles.planName}>{plan.name}</div>
+            <div
+              key={plan.id}
+              className={`${styles.planCard} ${plan.monthly_balance >= 0 ? styles.planCardPositive : styles.planCardNegative}`}
+            >
+              <div className={styles.planHeader}>
+                <span className={styles.planName}>{plan.name}</span>
+                <button
+                  className="btn"
+                  onClick={() => navigate(`/plans/${plan.id}`)}
+                >
+                  Öffnen
+                </button>
+              </div>
+
               {plan.description && (
                 <p className={styles.planDescription}>{plan.description}</p>
               )}
+
+              <div className={styles.planBalance}>
+                <span className={plan.monthly_balance >= 0 ? styles.balancePositive : styles.balanceNegative}>
+                  {formatCurrency(plan.monthly_balance)}
+                </span>
+                <span className={styles.balanceLabel}>monatliche Bilanz</span>
+              </div>
+
               <div className={styles.planStats}>
                 <div className={styles.statRow}>
                   <span className={styles.statLabel}>Einnahmen</span>
@@ -143,16 +163,11 @@ const PlansPage = () => {
                     {formatCurrency(plan.total_monthly_expenses)}
                   </span>
                 </div>
-                <div className={`${styles.statRow} ${styles.statRowBalance}`}>
-                  <span className={styles.statLabel}>Bilanz</span>
-                  <span className={plan.monthly_balance >= 0 ? styles.statPositive : styles.statNegative}>
-                    {formatCurrency(plan.monthly_balance)}
-                  </span>
-                </div>
               </div>
+
               <div className={styles.planFooter}>
                 <span className={styles.planMeta}>
-                  {plan.budget_item_count} Posten - Erstellt am {formatDate(plan.created_at)}
+                  {plan.budget_item_count} Posten · {formatDate(plan.created_at)}
                 </span>
                 <div className={styles.planActions}>
                   <button
@@ -166,12 +181,6 @@ const PlansPage = () => {
                     onClick={() => handleDelete(plan)}
                   >
                     Löschen
-                  </button>
-                  <button
-                    className="btn"
-                    onClick={() => navigate(`/plans/${plan.id}`)}
-                  >
-                    Details
                   </button>
                 </div>
               </div>

--- a/src/pages/PlansPage.module.css
+++ b/src/pages/PlansPage.module.css
@@ -1,6 +1,6 @@
 .container {
-  padding: 2rem;
-  max-width: 1200px;
+  padding: 2rem 1.5rem;
+  max-width: 1100px;
   margin: 0 auto;
 }
 
@@ -8,262 +8,331 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
 }
 
 .plansList {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
 }
 
+/* Plan card */
 .planCard {
   background-color: var(--section-bg);
-  padding: 1.5rem 2rem;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s, box-shadow 0.2s;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  border-top-width: 3px;
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  transition: box-shadow 0.15s, border-color 0.15s;
+  overflow: hidden;
 }
 
 .planCard:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.planCardPositive {
+  border-top-color: var(--color-income);
+}
+
+.planCardNegative {
+  border-top-color: var(--color-expense);
+}
+
+/* Card header: name + open button */
+.planHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1.125rem 1.25rem 0.75rem 1.25rem;
 }
 
 .planName {
-  font-family: "Rubik", sans-serif;
-  font-size: 20px;
-  font-weight: 800;
+  font-size: 15px;
+  font-weight: 600;
   color: var(--text-color);
-  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .planDescription {
-  color: var(--text-color);
-  opacity: 0.75;
-  margin-bottom: 1rem;
+  font-size: 12px;
+  color: var(--text-muted);
   line-height: 1.5;
+  padding: 0 1.25rem 0.75rem 1.25rem;
+  margin: 0;
 }
 
-.planStats {
-  margin: 1rem 0;
+/* Big balance display */
+.planBalance {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  border-top: 1px solid rgba(128, 128, 128, 0.2);
-  padding-top: 1rem;
+  gap: 0.1rem;
+  padding: 0.75rem 1.25rem 1rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+  background-color: var(--background-color);
+}
+
+.balancePositive {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-income);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.balanceNegative {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-expense);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.balanceLabel {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 500;
+}
+
+/* Income / expense rows */
+.planStats {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0.625rem 1.25rem;
 }
 
 .statRow {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 14px;
-}
-
-.statRowBalance {
-  border-top: 1px solid rgba(128, 128, 128, 0.2);
-  padding-top: 0.4rem;
-  margin-top: 0.2rem;
-  font-weight: 700;
+  font-size: 13px;
+  padding: 0.25rem 0;
 }
 
 .statLabel {
-  opacity: 0.7;
+  color: var(--text-muted);
 }
 
 .statIncome {
-  color: #2e7d32;
+  color: var(--color-income);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
 }
 
 .statExpenses {
-  color: #c62828;
+  color: var(--color-expense);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
 }
 
-.statPositive {
-  color: #2e7d32;
-}
+/* Unused - kept for compatibility */
+.statRowBalance { display: none; }
+.statPositive { color: var(--color-income); }
+.statNegative { color: var(--color-expense); }
 
-.statNegative {
-  color: #c62828;
-}
-
-:global([data-theme="dark"]) .statIncome,
-:global([data-theme="dark"]) .statPositive {
-  color: #66bb6a;
-}
-
-:global([data-theme="dark"]) .statExpenses,
-:global([data-theme="dark"]) .statNegative {
-  color: #ef9a9a;
-}
-
+/* Footer: meta + actions */
 .planFooter {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-top: 1rem;
+  padding: 0.625rem 1.25rem 0.875rem 1.25rem;
+  border-top: 1px solid var(--border-color);
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.planMeta {
+  font-size: 11px;
+  color: var(--text-subtle);
 }
 
 .planActions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.375rem;
 }
 
 .editBtn {
-  background: none;
-  border: 2px solid rgba(128, 128, 128, 0.4);
-  border-radius: 14px;
-  padding: 0.5rem 1rem;
+  background: var(--accent);
+  border: none;
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent-text);
   cursor: pointer;
-  font-family: "Roboto Mono", monospace;
-  font-size: 14px;
-  color: var(--text-color);
-  transition: border-color 0.2s, background-color 0.2s;
+  transition: background-color 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
 .editBtn:hover {
-  border-color: var(--text-color);
-  background-color: rgba(128, 128, 128, 0.1);
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.editBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .deleteBtn {
-  background: none;
-  border: 2px solid rgba(198, 40, 40, 0.4);
-  border-radius: 14px;
-  padding: 0.5rem 1rem;
+  background: var(--color-expense);
+  border: none;
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  font-size: 13px;
+  font-weight: 500;
+  color: #ffffff;
   cursor: pointer;
-  font-family: "Roboto Mono", monospace;
-  font-size: 14px;
-  color: #c62828;
-  transition: border-color 0.2s, background-color 0.2s;
+  transition: opacity 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
 .deleteBtn:hover {
-  border-color: #c62828;
-  background-color: rgba(198, 40, 40, 0.08);
+  opacity: 0.85;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(185, 28, 28, 0.25);
 }
 
-:global([data-theme="dark"]) .deleteBtn {
-  color: #ef9a9a;
-  border-color: rgba(239, 154, 154, 0.4);
-}
-
-:global([data-theme="dark"]) .deleteBtn:hover {
-  border-color: #ef9a9a;
-  background-color: rgba(239, 154, 154, 0.08);
-}
-
-.planMeta {
-  font-size: 13px;
-  opacity: 0.6;
-  color: var(--text-color);
+.deleteBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .loading {
   text-align: center;
   padding: 3rem;
-  font-size: 18px;
-  opacity: 0.7;
+  color: var(--text-muted);
 }
 
 .empty {
   text-align: center;
   padding: 4rem 2rem;
-  opacity: 0.75;
+  color: var(--text-muted);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 .error {
-  background-color: #ffebee;
-  color: #c62828;
-  padding: 1rem;
-  border-radius: 8px;
-  margin-bottom: 1rem;
+  background-color: rgba(220, 38, 38, 0.06);
+  color: var(--color-expense);
+  border: 1px solid rgba(220, 38, 38, 0.15);
+  padding: 0.75rem 1rem;
+  border-radius: 7px;
+  margin-bottom: 1.25rem;
+  font-size: 13px;
 }
 
-:global([data-theme="dark"]) .error {
-  background-color: #5d1f1f;
-  color: #ffcdd2;
-}
-
+/* Drawer (slide in from right) */
 .modal {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  background-color: rgba(0, 0, 0, 0.35);
   z-index: 1000;
-  padding: 1rem;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .modalContent {
   background-color: var(--section-bg);
-  padding: 2rem;
-  border-radius: 12px;
-  max-width: 500px;
   width: 100%;
+  max-width: 460px;
+  height: 100%;
+  overflow-y: auto;
+  padding: 2rem;
+  border-left: 1px solid var(--border-color);
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.1);
+  animation: drawerIn 0.22s ease-out;
+}
+
+@keyframes drawerIn {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+:global([data-theme="dark"]) .modalContent {
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.4);
 }
 
 .modalHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.75rem;
 }
 
 .closeBtn {
   background: none;
   border: none;
-  font-size: 28px;
-  cursor: pointer;
-  color: var(--text-color);
+  font-size: 20px;
   line-height: 1;
-  padding: 0 0.25rem;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 0.25rem 0.375rem;
+  border-radius: 4px;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.closeBtn:hover {
+  color: var(--text-color);
+  background-color: var(--sidebar-hover);
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .formGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.375rem;
 }
 
 .label {
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color);
 }
 
 .optional {
   font-weight: 400;
-  opacity: 0.6;
-  font-size: 13px;
+  color: var(--text-muted);
+  font-size: 12px;
 }
 
 .input {
-  padding: 0.8rem;
-  border: 2px solid transparent;
-  border-radius: 8px;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
   background-color: var(--input-bg);
   color: var(--text-color);
-  font-family: "Roboto Mono", monospace;
-  font-size: 15px;
-  outline: 2px solid rgba(128, 128, 128, 0.3);
+  font-size: 14px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  outline: none;
 }
 
 .input:focus {
-  outline: 2px solid var(--text-color);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
 }
 
 .textarea {
@@ -273,17 +342,35 @@
 
 .formActions {
   display: flex;
-  gap: 1rem;
+  gap: 0.625rem;
   justify-content: flex-end;
   margin-top: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.formActions :global(.btn):first-child {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+}
+
+.formActions :global(.btn):first-child:hover {
+  color: var(--text-color);
+  border-color: var(--border-hover);
+  background-color: var(--background-color);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 @media (width >= 800px) {
   .container {
-    padding: 3rem;
+    padding: 2.5rem 3rem;
   }
+}
 
-  .planName {
-    font-size: 22px;
+@media (width < 500px) {
+  .modalContent {
+    max-width: 100%;
   }
 }

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -31,7 +31,7 @@ const RegisterPage = () => {
     const result = await register({ email, password, name })
 
     if (result.success) {
-      navigate('/plans')
+      navigate('/dashboard')
     } else {
       setError(result.error || 'Registrierung fehlgeschlagen.')
     }

--- a/src/pages/RegisterPage.module.css
+++ b/src/pages/RegisterPage.module.css
@@ -1,93 +1,101 @@
+/* Used by both LoginPage.jsx and RegisterPage.jsx */
+
 .container {
   display: flex;
   justify-content: center;
   align-items: center;
   min-height: 100vh;
   padding: 2rem;
+  background-color: var(--background-color);
 }
 
 .formWrapper {
   background-color: var(--section-bg);
-  padding: 3rem;
-  border-radius: 16px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  max-width: 500px;
+  padding: 2.25rem 2.5rem;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-card);
+  max-width: 400px;
   width: 100%;
 }
 
 .title {
+  font-size: 20px;
+  font-weight: 700;
   text-align: center;
-  margin-bottom: 2rem;
+  margin-bottom: 1.75rem;
+  color: var(--text-color);
+  letter-spacing: -0.015em;
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.125rem;
 }
 
 .formGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .label {
-  font-weight: 700;
-  color: var(--form-text-color);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color);
 }
 
 .input {
-  padding: 0.8rem;
-  border: 2px solid var(--navlinks-border);
-  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
   background-color: var(--input-bg);
   color: var(--text-color);
-  font-family: "Roboto Mono", monospace;
-  font-size: 16px;
-  transition: border-color 0.2s;
+  font-size: 14px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  outline: none;
+  width: 100%;
 }
 
 .input:focus {
-  outline: none;
-  border-color: var(--text-color);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
 }
 
 .input:disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
 .error {
-  color: #d32f2f;
-  font-size: 14px;
+  color: var(--color-expense);
+  font-size: 13px;
   margin: 0;
+  padding: 0.6rem 0.75rem;
+  background-color: rgba(220, 38, 38, 0.06);
+  border: 1px solid rgba(220, 38, 38, 0.15);
+  border-radius: 6px;
 }
 
-.success {
-  color: #2e7d32;
-  font-size: 14px;
-  margin: 0;
+:global([data-theme="dark"]) .error {
+  background-color: rgba(248, 113, 113, 0.08);
+  border-color: rgba(248, 113, 113, 0.2);
 }
 
 .footer {
   text-align: center;
   margin-top: 1.5rem;
-  color: var(--form-text-color);
+  font-size: 13px;
+  color: var(--text-muted);
 }
 
 .link {
-  color: var(--text-color);
-  font-weight: 700;
+  color: var(--accent);
+  font-weight: 600;
   text-decoration: none;
 }
 
 .link:hover {
   text-decoration: underline;
-}
-
-@media (width >= 800px) {
-  .input {
-    font-size: 18px;
-  }
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;400;700&family=Rubik:wght@800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 * {
   box-sizing: border-box;
@@ -9,11 +9,115 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* Surfaces */
+  --background-color: #e8e3db;
+  --section-bg: #ffffff;
+  --section-header-bg: #e8e3db;
+  --border-color: #cdc8c0;
+  --border-hover: #a8a39b;
+
+  /* Text */
+  --text-color: #111827;
+  --text-muted: #6b7280;
+  --text-subtle: #9ca3af;
+
+  /* Interactive */
+  --accent: #1a1a1a;
+  --accent-hover: #3a3a3a;
+  --accent-text: #ffffff;
+  --accent-subtle: rgba(0, 0, 0, 0.07);
+
+  /* Inputs */
+  --input-bg: #f9f8f6;
+
+  /* Navigation / Sidebar */
+  --nav-bg: #ffffff;
+  --sidebar-bg: #dcd7cf;
+  --sidebar-hover: rgba(0, 0, 0, 0.06);
+  --sidebar-active-bg: rgba(0, 0, 0, 0.08);
+
+  /* Financial */
+  --color-income: #166534;
+  --color-expense: #b91c1c;
+
+  /* Shadows */
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-modal: 0 8px 24px rgba(0, 0, 0, 0.1), 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="dark"] {
+  --background-color: #0f1117;
+  --section-bg: #1a1d27;
+  --section-header-bg: #0f1117;
+  --border-color: #2d3348;
+  --border-hover: #3d4460;
+
+  --text-color: #f1f3f9;
+  --text-muted: #8b92a8;
+  --text-subtle: #5c6480;
+
+  --accent: #ffffff;
+  --accent-hover: #e0e0e0;
+  --accent-text: #111827;
+  --accent-subtle: rgba(255, 255, 255, 0.1);
+
+  --input-bg: #0f1117;
+  --nav-bg: #1a1d27;
+  --sidebar-bg: #0a0d14;
+  --sidebar-hover: rgba(255, 255, 255, 0.07);
+  --sidebar-active-bg: rgba(255, 255, 255, 0.1);
+
+  --color-income: #34d399;
+  --color-expense: #f87171;
+
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-modal: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
 body {
   margin: 0;
   padding: 0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  line-height: 1.5;
+}
+
+h1,
+h2,
+h3 {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-weight: 700;
+  color: var(--text-color);
+  margin: 0;
+  padding: 0;
+  line-height: 1.3;
+  letter-spacing: -0.015em;
+}
+
+h1 { font-size: 26px; }
+h2 { font-size: 17px; font-weight: 600; letter-spacing: -0.01em; }
+h3 { font-size: 14px; font-weight: 600; letter-spacing: 0; }
+
+p,
+td,
+th,
+label,
+input,
+button,
+select,
+textarea,
+span {
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-size: 14px;
+  color: var(--text-color);
+}
+
+p {
+  margin: 0;
+  line-height: 1.6;
 }
 
 a {


### PR DESCRIPTION
- Replace Roboto Mono/Rubik fonts and olive/pill-nav aesthetic with Inter font and a neutral, professional finance app design

- Add fixed left sidebar (220px) with NavLink active states, theme toggle and user avatar; replace top Navbar layout

- Implement DashboardPage with active plan selector and plan comparison table (up to 3 plans, localStorage-persisted)

- Redesign plan cards with colored top border (income/expense), prominent monthly balance figure and drawer modals on all pages

- Unify all buttons: primary/edit use accent (black/white per theme), delete uses solid red; add translateY hover animation across all

- Fix post-login redirect from /plans to /dashboard