### PR TITLE
fix: improve login/register page responsiveness and theme toggle

### DIFF
--- a/src/pages/RegisterPage.module.css
+++ b/src/pages/RegisterPage.module.css
@@ -35,10 +35,11 @@
 }
 
 .brandMark {
-  width: 580px;
-  height: 580px;
+  width: min(580px, 90vw);
+  height: min(580px, 90vw);
   object-fit: contain;
   margin-bottom: -8rem;
+  pointer-events: none;
 }
 
 .brandName {
@@ -148,6 +149,7 @@
   position: fixed;
   top: 1rem;
   right: 1rem;
+  z-index: 50;
   background: var(--section-bg);
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -173,4 +175,51 @@
 :global([data-theme="dark"]) .themeToggle img {
   filter: brightness(0) invert(1);
   opacity: 0.8;
+}
+
+/* Tablet */
+@media (max-width: 640px) {
+  .container {
+    padding: 1.25rem;
+  }
+
+  .group {
+    transform: translateY(-5rem);
+    max-width: 100%;
+  }
+
+  .brandMark {
+    width: min(380px, 85vw);
+    height: min(380px, 85vw);
+    margin-bottom: -5rem;
+  }
+
+  .tagline {
+    font-size: 16px;
+  }
+
+  .formWrapper {
+    padding: 1.75rem 1.5rem;
+  }
+}
+
+/* Mobile */
+@media (max-width: 400px) {
+  .group {
+    transform: translateY(-3rem);
+  }
+
+  .brandMark {
+    width: min(280px, 80vw);
+    height: min(280px, 80vw);
+    margin-bottom: -3.5rem;
+  }
+
+  .tagline {
+    font-size: 14px;
+  }
+
+  .formWrapper {
+    padding: 1.5rem 1.25rem;
+  }
 }


### PR DESCRIPTION
- Scale logo responsively with min() to prevent overflow on small screens

- Add media queries for tablet (640px) and mobile (400px) with reduced logo size, negative margin and translateY values

- Fix theme toggle button being blocked by logo SVG transparent area: add pointer-events: none to logo and z-index: 50 to toggle button