### PR TITLE
feat(frontend): implement category filter for budget items (US-051)

### DIFF
--- a/src/pages/PlanDetailPage.jsx
+++ b/src/pages/PlanDetailPage.jsx
@@ -94,6 +94,7 @@ const PlanDetailPage = () => {
   const [sortField, setSortField] = useState('monthly_amount')
   const [sortDir, setSortDir] = useState('desc')
   const [searchQuery, setSearchQuery] = useState('')
+  const [selectedCategories, setSelectedCategories] = useState(new Set())
 
   const [showModal, setShowModal] = useState(false)
   const [editingItem, setEditingItem] = useState(null)
@@ -287,16 +288,35 @@ const PlanDetailPage = () => {
   const incomeItems = items.filter((i) => i.type === 'income')
   const expenseItems = items.filter((i) => i.type === 'expense')
 
-  const filteredItems = searchQuery.trim()
-    ? items.filter((item) => {
-        const q = searchQuery.toLowerCase()
-        return (
-          item.description.toLowerCase().includes(q) ||
-          getCategoryName(item.category_id).toLowerCase().includes(q) ||
-          (item.note && item.note.toLowerCase().includes(q))
-        )
-      })
-    : items
+  const availableCategories = categories.filter((c) =>
+    items.some((i) => i.category_id === c.id)
+  )
+
+  const toggleCategory = (catId) => {
+    setSelectedCategories((prev) => {
+      const next = new Set(prev)
+      next.has(catId) ? next.delete(catId) : next.add(catId)
+      return next
+    })
+  }
+
+  const resetFilters = () => {
+    setSearchQuery('')
+    setSelectedCategories(new Set())
+  }
+
+  const hasActiveFilters = searchQuery.trim() || selectedCategories.size > 0
+
+  const filteredItems = items.filter((item) => {
+    const q = searchQuery.toLowerCase().trim()
+    const matchesSearch = !q || (
+      item.description.toLowerCase().includes(q) ||
+      getCategoryName(item.category_id).toLowerCase().includes(q) ||
+      (item.note && item.note.toLowerCase().includes(q))
+    )
+    const matchesCategory = selectedCategories.size === 0 || selectedCategories.has(item.category_id)
+    return matchesSearch && matchesCategory
+  })
 
   const filteredIncomeItems = filteredItems.filter((i) => i.type === 'income')
   const filteredExpenseItems = filteredItems.filter((i) => i.type === 'expense')
@@ -526,6 +546,26 @@ const PlanDetailPage = () => {
                 )}
               </div>
 
+              {availableCategories.length > 0 && (
+                <div className={styles.filterBar}>
+                  <span className={styles.sortLabel}>Kategorie:</span>
+                  {availableCategories.map((cat) => (
+                    <button
+                      key={cat.id}
+                      className={`${styles.filterBtn} ${selectedCategories.has(cat.id) ? styles.filterBtnActive : ''}`}
+                      onClick={() => toggleCategory(cat.id)}
+                    >
+                      {cat.name}
+                    </button>
+                  ))}
+                  {hasActiveFilters && (
+                    <button className={styles.filterReset} onClick={resetFilters}>
+                      Zurücksetzen
+                    </button>
+                  )}
+                </div>
+              )}
+
               <div className={styles.sortBar}>
                 <span className={styles.sortLabel}>Sortieren:</span>
                 {[
@@ -545,9 +585,9 @@ const PlanDetailPage = () => {
                 ))}
               </div>
 
-              {filteredItems.length === 0 && searchQuery ? (
+              {filteredItems.length === 0 && hasActiveFilters ? (
                 <div className={styles.searchEmpty}>
-                  Keine Ergebnisse für „{searchQuery}".
+                  Keine Ergebnisse für die gewählten Filter.
                 </div>
               ) : (
                 <div className={styles.sections}>

--- a/src/pages/PlanDetailPage.module.css
+++ b/src/pages/PlanDetailPage.module.css
@@ -387,6 +387,61 @@
   font-size: 14px;
 }
 
+.filterBar {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.625rem;
+}
+
+.filterBtn {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  padding: 0.275rem 0.75rem;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  color: var(--text-muted);
+  transition: border-color 0.15s, color 0.15s, background-color 0.15s, transform 0.15s;
+  white-space: nowrap;
+}
+
+.filterBtn:hover {
+  border-color: var(--border-hover);
+  color: var(--text-color);
+  transform: translateY(-1px);
+}
+
+.filterBtn:active {
+  transform: translateY(0);
+}
+
+.filterBtnActive {
+  border-color: var(--accent);
+  color: var(--accent);
+  background-color: var(--accent-subtle);
+  font-weight: 600;
+}
+
+.filterReset {
+  background: none;
+  border: none;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-expense);
+  cursor: pointer;
+  padding: 0.275rem 0.5rem;
+  border-radius: 20px;
+  transition: background-color 0.12s;
+  margin-left: 0.25rem;
+}
+
+.filterReset:hover {
+  background-color: rgba(220, 38, 38, 0.06);
+}
+
 .sortBar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Add multi-select category filter pills to the budget items tab in PlanDetailPage. Filters combine with the existing search (US-050) via filteredItems derived state.

- selectedCategories state as Set for O(1) toggle/lookup

- availableCategories derived from current items (only shows relevant cats)

- toggleCategory() adds/removes from Set, resetFilters() clears both filters

- hasActiveFilters drives visibility of reset button

- Filter pills use accent color when active (filterBtnActive class)

- Reset button shown only when search or category filter is active

- filteredItems combines search query and category filter