### PR TITLE
feat(frontend): implement plan duplicate UI (US-052)

### DIFF
--- a/src/pages/PlansPage.jsx
+++ b/src/pages/PlansPage.jsx
@@ -12,6 +12,7 @@ const PlansPage = () => {
   const [formData, setFormData] = useState({ name: '', description: '' })
   const [submitting, setSubmitting] = useState(false)
   const [formError, setFormError] = useState('')
+  const [duplicatingId, setDuplicatingId] = useState(null)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -48,6 +49,17 @@ const PlansPage = () => {
   const handleChange = (e) => {
     const { name, value } = e.target
     setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleDuplicate = async (plan) => {
+    setDuplicatingId(plan.id)
+    try {
+      const newPlan = await api.duplicatePlan(plan.id)
+      navigate(`/plans/${newPlan.id}`)
+    } catch (err) {
+      setError(err.message)
+      setDuplicatingId(null)
+    }
   }
 
   const handleDelete = async (plan) => {
@@ -170,6 +182,13 @@ const PlansPage = () => {
                   {plan.budget_item_count} Posten · {formatDate(plan.created_at)}
                 </span>
                 <div className={styles.planActions}>
+                  <button
+                    className={styles.duplicateBtn}
+                    onClick={() => handleDuplicate(plan)}
+                    disabled={duplicatingId === plan.id}
+                  >
+                    {duplicatingId === plan.id ? 'Wird dupliziert...' : 'Duplizieren'}
+                  </button>
                   <button
                     className={styles.editBtn}
                     onClick={() => handleOpenModal(plan)}

--- a/src/pages/PlansPage.module.css
+++ b/src/pages/PlansPage.module.css
@@ -165,6 +165,37 @@
   gap: 0.375rem;
 }
 
+.duplicateBtn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
+  padding: 0.4rem 0.875rem;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+}
+
+.duplicateBtn:hover {
+  color: var(--text-color);
+  border-color: var(--border-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.duplicateBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.duplicateBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
 .editBtn {
   background: var(--accent);
   border: none;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -154,6 +154,10 @@ export async function getPlan(planId) {
   return request(`/plans/${planId}`)
 }
 
+export async function duplicatePlan(planId) {
+  return request(`/plans/${planId}/duplicate`, { method: 'POST' })
+}
+
 export async function deletePlan(planId) {
   const token = localStorage.getItem('token')
   const headers = {}


### PR DESCRIPTION
Add "Duplizieren" button to each plan card that calls POST /plans/{id}/duplicate and navigates to the newly created plan.

- duplicatePlan() added to api.js

- duplicatingId state tracks in-flight request per plan

- duplicateBtn: ghost style to differentiate from primary actions