### PR TITLE
feat(frontend): add export dropdown for PDF and CSV (US-053/054)

### DIFF
--- a/src/pages/PlanDetailPage.jsx
+++ b/src/pages/PlanDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import * as api from '../utils/api'
 import styles from './PlanDetailPage.module.css'
@@ -101,6 +101,9 @@ const PlanDetailPage = () => {
   const [formData, setFormData] = useState(emptyForm)
   const [submitting, setSubmitting] = useState(false)
   const [formError, setFormError] = useState('')
+  const [exporting, setExporting] = useState(false)
+  const [showExportMenu, setShowExportMenu] = useState(false)
+  const exportMenuRef = useRef(null)
 
   useEffect(() => {
     loadAll()
@@ -151,6 +154,37 @@ const PlanDetailPage = () => {
       }))
       .sort((a, b) => b.amount - a.amount)
       .map((c, i) => ({ ...c, color: CATEGORY_COLORS[i % CATEGORY_COLORS.length] }))
+  }
+
+  useEffect(() => {
+    const handleOutsideClick = (e) => {
+      if (exportMenuRef.current && !exportMenuRef.current.contains(e.target)) {
+        setShowExportMenu(false)
+      }
+    }
+    document.addEventListener('mousedown', handleOutsideClick)
+    return () => document.removeEventListener('mousedown', handleOutsideClick)
+  }, [])
+
+  const handleExport = async (type) => {
+    setShowExportMenu(false)
+    setExporting(true)
+    try {
+      const blob = type === 'pdf'
+        ? await api.exportPlanPDF(planId)
+        : await api.exportPlanCSV(planId)
+      const ext = type === 'pdf' ? 'pdf' : 'csv'
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${plan.name}.${ext}`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setExporting(false)
+    }
   }
 
   const handleSort = (field) => {
@@ -374,9 +408,31 @@ const PlanDetailPage = () => {
             <p className={styles.description}>{plan.description}</p>
           )}
         </div>
-        <button className="btn" onClick={() => handleOpenModal()}>
-          Posten hinzufügen
-        </button>
+        <div className={styles.headerActions}>
+          <div className={styles.exportWrapper} ref={exportMenuRef}>
+            <button
+              className={styles.exportBtn}
+              onClick={() => setShowExportMenu((o) => !o)}
+              disabled={exporting}
+            >
+              {exporting ? 'Wird exportiert...' : 'Exportieren'}
+              {!exporting && <span className={styles.exportCaret}>&#9660;</span>}
+            </button>
+            {showExportMenu && (
+              <div className={styles.exportMenu}>
+                <button className={styles.exportMenuItem} onClick={() => handleExport('pdf')}>
+                  PDF exportieren
+                </button>
+                <button className={styles.exportMenuItem} onClick={() => handleExport('csv')}>
+                  CSV exportieren
+                </button>
+              </div>
+            )}
+          </div>
+          <button className="btn" onClick={() => handleOpenModal()}>
+            Posten hinzufügen
+          </button>
+        </div>
       </div>
 
       <div className={styles.statsBar}>

--- a/src/pages/PlanDetailPage.module.css
+++ b/src/pages/PlanDetailPage.module.css
@@ -40,6 +40,95 @@
   flex: 1;
 }
 
+.headerActions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.exportWrapper {
+  position: relative;
+}
+
+.exportBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  background: var(--accent);
+  border: none;
+  border-radius: 7px;
+  padding: 0.55rem 1.2rem;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: 'Inter', system-ui, sans-serif;
+  color: var(--accent-text);
+  cursor: pointer;
+  transition: background-color 0.15s, transform 0.15s, box-shadow 0.15s;
+  white-space: nowrap;
+}
+
+.exportBtn:hover {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.exportBtn:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.exportBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.exportCaret {
+  font-size: 9px;
+  color: var(--accent-text);
+  opacity: 0.4;
+  line-height: 1;
+}
+
+.exportMenu {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  right: 0;
+  background-color: var(--section-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  z-index: 100;
+  min-width: 160px;
+  overflow: hidden;
+}
+
+:global([data-theme="dark"]) .exportMenu {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.exportMenuItem {
+  display: block;
+  width: 100%;
+  padding: 0.625rem 1rem;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-color);
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.12s;
+}
+
+.exportMenuItem:hover {
+  background-color: var(--background-color);
+}
+
 .headerTitle h1 {
   margin: 0 0 0.2rem 0;
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -154,6 +154,26 @@ export async function getPlan(planId) {
   return request(`/plans/${planId}`)
 }
 
+async function exportFile(url) {
+  const token = localStorage.getItem('token')
+  const headers = {}
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  const response = await fetch(url, { headers })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.detail || `HTTP ${response.status}`)
+  }
+  return response.blob()
+}
+
+export async function exportPlanPDF(planId) {
+  return exportFile(`/api/v1/plans/${planId}/export/pdf`)
+}
+
+export async function exportPlanCSV(planId) {
+  return exportFile(`/api/v1/plans/${planId}/export/csv`)
+}
+
 export async function duplicatePlan(planId) {
   return request(`/plans/${planId}/duplicate`, { method: 'POST' })
 }


### PR DESCRIPTION
Replace single export button with a dropdown menu offering PDF and CSV export. Both formats use a shared exportFile() helper with auth token handling and trigger a blob download via programmatic anchor click.

- exportPlanPDF() and exportPlanCSV() added to api.js

- showExportMenu state with outside-click detection via useRef

- handleExport(type) builds blob URL, sets filename and clicks download

- Export button styled consistently with other accent buttons

- Dropdown caret visually dimmed (opacity: 0.4) to indicate dropdown