### PR TITLE
feat(frontend): rename CSV export to Excel, update to xlsx extension

### DIFF
--- a/src/pages/PlanDetailPage.jsx
+++ b/src/pages/PlanDetailPage.jsx
@@ -172,8 +172,8 @@ const PlanDetailPage = () => {
     try {
       const blob = type === 'pdf'
         ? await api.exportPlanPDF(planId)
-        : await api.exportPlanCSV(planId)
-      const ext = type === 'pdf' ? 'pdf' : 'csv'
+        : await api.exportPlanExcel(planId)
+      const ext = type === 'pdf' ? 'pdf' : 'xlsx'
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
@@ -423,8 +423,8 @@ const PlanDetailPage = () => {
                 <button className={styles.exportMenuItem} onClick={() => handleExport('pdf')}>
                   PDF exportieren
                 </button>
-                <button className={styles.exportMenuItem} onClick={() => handleExport('csv')}>
-                  CSV exportieren
+                <button className={styles.exportMenuItem} onClick={() => handleExport('excel')}>
+                  Excel exportieren
                 </button>
               </div>
             )}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -170,7 +170,7 @@ export async function exportPlanPDF(planId) {
   return exportFile(`/api/v1/plans/${planId}/export/pdf`)
 }
 
-export async function exportPlanCSV(planId) {
+export async function exportPlanExcel(planId) {
   return exportFile(`/api/v1/plans/${planId}/export/csv`)
 }
 


### PR DESCRIPTION
Update export dropdown label from "CSV exportieren" to "Excel exportieren", download filename uses .xlsx extension, and api.js function renamed from exportPlanCSV to exportPlanExcel.