### PR TITLE
Replace language flag buttons with single flag dropdown

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -17,11 +17,14 @@ const Sidebar = () => {
   const { lang, setLang, t } = useLanguage()
   const navigate = useNavigate()
   const [menuOpen, setMenuOpen] = useState(false)
+  const [langOpen, setLangOpen] = useState(false)
   const menuRef = useRef(null)
+  const langRef = useRef(null)
 
   useEffect(() => {
     const handleClickOutside = (e) => {
       if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false)
+      if (langRef.current && !langRef.current.contains(e.target)) setLangOpen(false)
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
@@ -121,21 +124,32 @@ const Sidebar = () => {
             </button>
           </div>
 
-          <div className={styles.iconGroup}>
+          <div className={styles.langDropdownWrapper} ref={langRef}>
             <button
-              className={`${styles.iconBtn} ${lang === 'de' ? styles.iconBtnActive : ''}`}
-              onClick={() => setLang('de')}
-              aria-label="Deutsch"
+              className={`${styles.iconBtn} ${langOpen ? styles.iconBtnActive : ''}`}
+              onClick={() => setLangOpen((o) => !o)}
+              aria-label="Sprache wählen"
             >
-              <img src={flagDe} className={styles.iconBtnFlag} alt="DE" />
+              <img src={lang === 'de' ? flagDe : flagGb} className={styles.iconBtnFlag} alt={lang.toUpperCase()} />
             </button>
-            <button
-              className={`${styles.iconBtn} ${lang === 'en' ? styles.iconBtnActive : ''}`}
-              onClick={() => setLang('en')}
-              aria-label="English"
-            >
-              <img src={flagGb} className={styles.iconBtnFlag} alt="EN" />
-            </button>
+            {langOpen && (
+              <div className={styles.langDropdown}>
+                <button
+                  className={`${styles.langOption} ${lang === 'de' ? styles.langOptionActive : ''}`}
+                  onClick={() => { setLang('de'); setLangOpen(false) }}
+                >
+                  <img src={flagDe} className={styles.iconBtnFlag} alt="" />
+                  <span>Deutsch</span>
+                </button>
+                <button
+                  className={`${styles.langOption} ${lang === 'en' ? styles.langOptionActive : ''}`}
+                  onClick={() => { setLang('en'); setLangOpen(false) }}
+                >
+                  <img src={flagGb} className={styles.iconBtnFlag} alt="" />
+                  <span>English</span>
+                </button>
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/Sidebar.module.css
+++ b/src/components/Sidebar.module.css
@@ -158,6 +158,50 @@
   border-radius: 3px;
 }
 
+/* Language dropdown */
+.langDropdownWrapper {
+  position: relative;
+}
+
+.langDropdown {
+  position: absolute;
+  bottom: calc(100% + 0.375rem);
+  right: 0;
+  background-color: var(--section-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: var(--shadow-modal);
+  overflow: hidden;
+  z-index: 200;
+  animation: menuIn 0.12s ease-out;
+  min-width: 130px;
+}
+
+.langOption {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-color);
+  text-align: left;
+  transition: background-color 0.12s;
+}
+
+.langOption:hover {
+  background-color: var(--sidebar-hover);
+}
+
+.langOptionActive {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 /* User section */
 .userSection {
   position: relative;
@@ -360,6 +404,12 @@
   .iconBtnFlag {
     width: 18px;
     height: 18px;
+  }
+
+  .langDropdown {
+    bottom: auto;
+    top: calc(100% + 0.375rem);
+    right: 0;
   }
 
   .userButton {


### PR DESCRIPTION
Show only the active language flag as a button. Clicking it opens a dropdown to switch between German and English.